### PR TITLE
feat(linux): add geekbench workloads

### DIFF
--- a/workloads/linux/geekbench-common.mk
+++ b/workloads/linux/geekbench-common.mk
@@ -1,0 +1,40 @@
+GEEKBENCH_DEFAULT_DTB = $(if $(DEFAULT_DTB),$(DEFAULT_DTB),xiangshan-fpga-noAIA)
+
+define add_workload_linux_geekbench
+# Download files
+build/linux-workloads/$(1)/download/sentinel: $$(shell find $$(abspath workloads/linux/$(1)) -iname 'links.txt')
+	mkdir -p build/linux-workloads/$(1)/
+	bash scripts/download-files.sh workloads/linux/$(1) build/linux-workloads/$(1)/download
+
+# Track Geekbench-specific build options without making generic Linux workload
+# rules aware of them.
+build/linux-workloads/$(1)/build-vars.$$(shell printf '%s\n%s' "$$(PROFILING)" "$$(GEEKBENCH_ARGS)" | sha256sum | cut -d ' ' -f 1):
+	mkdir -p build/linux-workloads/$(1)
+	rm -f build/linux-workloads/$(1)/build-vars.*
+	touch $$@
+
+# Build and pack workload
+build/linux-workloads/$(1)/rootfs.cpio: $$(shell find $$(abspath workloads/linux/$(1))) $(TOOLCHAIN_WRAPPER) build/linux-workloads/$(1)/download/sentinel build/linux-workloads/$(1)/build-vars.$$(shell printf '%s\n%s' "$$(PROFILING)" "$$(GEEKBENCH_ARGS)" | sha256sum | cut -d ' ' -f 1) scripts/build-workload-linux.sh
+	CROSS_COMPILE="$$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
+	SYSROOT_DIR="$$(abspath $(BUILDROOT_DIR)/output/staging)" \
+	BUILDROOT_DIR="$$(abspath $(BUILDROOT_DIR))" \
+	PROFILING="$(PROFILING)" \
+	GEEKBENCH_ARGS="$(GEEKBENCH_ARGS)" \
+	bash scripts/build-workload-linux.sh workloads/linux/$(1) build/linux-workloads/$(1)
+
+# Build all-in-one firmware
+build/linux-workloads/$(1)/fw_payload.bin: $$(shell find $$(abspath dts)) $(GCPT_BIN) dts/xiangshan.dts.in scripts/build-sbi.sh scripts/build-firmware-linux.sh build/linux-workloads/$(1)/rootfs.cpio $(LINUX_IMAGE) build/opensbi/build/platform/generic/firmware/fw_jump.bin
+	CROSS_COMPILE="$$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
+	DTC="$$(abspath $(BUILDROOT_DIR)/output/host/bin)/dtc" \
+	DEFAULT_DTB="$(GEEKBENCH_DEFAULT_DTB)" \
+	bash scripts/build-firmware-linux.sh $(GCPT_BIN) build/opensbi dts $(LINUX_IMAGE) build/linux-workloads/$(1)
+
+linux/$(1): build/linux-workloads/$(1)/fw_payload.bin
+
+WORKLOAD_PHONY_TARGETS += linux/$(1)
+WORKLOAD_DIRS += build/linux-workloads/$(1)
+WORKLOADS_LINUX += build/linux-workloads/$(1)/fw_payload.bin
+ROOTFS += build/linux-workloads/$(1)/rootfs.cpio
+DT_DIRS += build/linux-workloads/$(1)/dt
+TARFLAGS += --transform='s|^build/linux-workloads/$(1)|workloads/linux/$(1)|'
+endef

--- a/workloads/linux/geekbench5/README.md
+++ b/workloads/linux/geekbench5/README.md
@@ -1,0 +1,50 @@
+# Geekbench 5
+
+This workload packages the Geekbench 5.5.1 Linux/RISC-V Preview binaries into a
+Linux initramfs workload.
+
+Build the all-in-one NEMU firmware image:
+
+```shell
+make linux/geekbench5
+```
+
+The resulting firmware is written to `build/linux-workloads/geekbench5/` as
+`fw_payload.bin`, with the unpacked initramfs in `rootfs.cpio` and generated
+device trees in `dt/`.
+
+This workload uses `dts/xiangshan-fpga-noAIA.dts.in` as its built-in default
+device tree so the large Geekbench initramfs stays inside Linux-visible memory.
+
+The automated boot path runs `./geekbench_riscv64 --cpu --iterations 1` so the
+simulator validation can reach a good trap in reasonable time. The default DTB
+describes one hart, so the Preview CPU run is single-core in this workload.
+
+Set `GEEKBENCH_ARGS='...'` at build time to change the Geekbench CLI. The
+default is `--cpu --iterations 1`:
+
+```shell
+GEEKBENCH_ARGS='--sysinfo' make linux/geekbench5
+```
+
+The boot script calls `nemu-trap 0` after the Geekbench process returns. This is
+intentional: the Preview binary may return a non-zero status when it cannot
+upload results, but reaching this point still means the benchmark path
+completed. The generated inittab also appends `nemu-trap -1` after
+`/geekbench/run.sh` as a fallback for cases where the run script exits before
+issuing its own trap.
+
+By default, no trap is emitted before the workload starts. Build with
+`PROFILING=1` to emit `nemu-trap 257` from inittab before the benchmark starts:
+
+```shell
+PROFILING=1 make linux/geekbench5
+```
+
+If you have a Pro-capable Geekbench binary, you can add `--single-core` or
+`--multi-core` in `GEEKBENCH_ARGS`. The Preview binaries in this repo reject
+both switches as Pro-only.
+
+The Geekbench Preview binary exposes only the full CPU benchmark and sysinfo
+commands. Individual workload switches are present in the binary but require
+Geekbench Pro, so this workload builds the runnable CPU benchmark image.

--- a/workloads/linux/geekbench5/build.sh
+++ b/workloads/linux/geekbench5/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive="$SRC_DIR/Geekbench-5.5.1-LinuxRISCVPreview.tar.gz"
+extract_dir="$SRC_DIR/geekbench"
+payload_dir="$PKG_DIR/geekbench"
+
+rm -rf "$extract_dir"
+mkdir -p "$extract_dir" "$payload_dir"
+tar -C "$extract_dir" --strip-components=1 -xf "$archive"
+
+install -m 755 "$extract_dir/geekbench5" "$payload_dir/geekbench5"
+install -m 755 "$extract_dir/geekbench_riscv64" "$payload_dir/geekbench_riscv64"
+install -m 644 "$extract_dir/geekbench.plar" "$payload_dir/geekbench.plar"
+install -m 755 "$WORKLOAD_DIR/run.sh" "$payload_dir/run.sh"
+mkdir -p "$PKG_DIR/etc"
+mkdir -p "$PKG_DIR/etc/default"
+printf 'GEEKBENCH_ARGS=%q\n' "${GEEKBENCH_ARGS:---cpu --iterations 1}" > "$PKG_DIR/etc/default/geekbench"
+if [ "${PROFILING:-0}" = 1 ]; then
+    printf '::sysinit:sh -c "nemu-trap 257"\n' > "$PKG_DIR/etc/inittab"
+fi
+printf '::once:sh -c "/geekbench/run.sh; nemu-trap -1"\n' >> "$PKG_DIR/etc/inittab"

--- a/workloads/linux/geekbench5/links.txt
+++ b/workloads/linux/geekbench5/links.txt
@@ -1,0 +1,1 @@
+Geekbench-5.5.1-LinuxRISCVPreview.tar.gz https://cdn.geekbench.com/Geekbench-5.5.1-LinuxRISCVPreview.tar.gz 65070301ccedd33bfd4797a19e9d28991fe719cc38570dbc445b8355a5b9bc64

--- a/workloads/linux/geekbench5/rules.mk
+++ b/workloads/linux/geekbench5/rules.mk
@@ -1,0 +1,2 @@
+include workloads/linux/geekbench-common.mk
+$(eval $(call add_workload_linux_geekbench,geekbench5))

--- a/workloads/linux/geekbench5/run.sh
+++ b/workloads/linux/geekbench5/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -x
+
+if [ -r /etc/default/geekbench ]; then
+    . /etc/default/geekbench
+fi
+GEEKBENCH_ARGS="${GEEKBENCH_ARGS:---cpu --iterations 1}"
+
+mkdir -p /proc /sys
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+
+cd /geekbench
+./geekbench_riscv64 $GEEKBENCH_ARGS
+# Geekbench may fail after the benchmark when it cannot upload results, so
+# treat reaching this point as successful workload completion.
+nemu-trap 0

--- a/workloads/linux/geekbench6/README.md
+++ b/workloads/linux/geekbench6/README.md
@@ -1,0 +1,55 @@
+# Geekbench 6
+
+This workload packages the Geekbench 6.7.0 Linux/RISC-V Preview binaries into a
+Linux initramfs workload.
+
+Build the all-in-one NEMU firmware image:
+
+```shell
+make linux/geekbench6
+```
+
+The resulting firmware is written to `build/linux-workloads/geekbench6/` as
+`fw_payload.bin`, with the unpacked initramfs in `rootfs.cpio` and generated
+device trees in `dt/`.
+
+This workload uses `dts/xiangshan-fpga-noAIA.dts.in` as its built-in default
+device tree so the large Geekbench initramfs stays inside Linux-visible memory.
+
+The automated boot path runs `./geekbench_riscv64 --cpu --iterations 1` so the
+simulator validation can reach a good trap in reasonable time. The default DTB
+describes one hart, so the Preview CPU run is single-core in this workload.
+
+Set `GEEKBENCH_ARGS='...'` at build time to change the Geekbench CLI. The
+default is `--cpu --iterations 1`:
+
+```shell
+GEEKBENCH_ARGS='--sysinfo' make linux/geekbench6
+```
+
+The boot script calls `nemu-trap 0` after the Geekbench process returns. This is
+intentional: the Preview binary may return a non-zero status when it cannot
+upload results, but reaching this point still means the benchmark path
+completed. The generated inittab also appends `nemu-trap -1` after
+`/geekbench/run.sh` as a fallback for cases where the run script exits before
+issuing its own trap.
+
+By default, no trap is emitted before the workload starts. Build with
+`PROFILING=1` to emit `nemu-trap 256` and `nemu-trap 257` from inittab before
+the benchmark starts:
+
+```shell
+PROFILING=1 make linux/geekbench6
+```
+
+If you have a Pro-capable Geekbench binary, you can add `--single-core` or
+`--multi-core` in `GEEKBENCH_ARGS`. The Preview binaries in this repo reject
+both switches as Pro-only.
+
+The tarball also includes `geekbench_rv64gcv`; it is installed in the image for
+manual use, while the automatic boot path runs the scalar `geekbench_riscv64`
+binary for broader simulator compatibility.
+
+The Geekbench Preview binary exposes only the full CPU benchmark and sysinfo
+commands. Individual workload switches are present in the binary but require
+Geekbench Pro, so this workload builds the runnable CPU benchmark image.

--- a/workloads/linux/geekbench6/build.sh
+++ b/workloads/linux/geekbench6/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive="$SRC_DIR/Geekbench-6.7.0-LinuxRISCVPreview.tar.gz"
+extract_dir="$SRC_DIR/geekbench"
+payload_dir="$PKG_DIR/geekbench"
+
+rm -rf "$extract_dir"
+mkdir -p "$extract_dir" "$payload_dir"
+tar -C "$extract_dir" --strip-components=1 -xf "$archive"
+
+install -m 755 "$extract_dir/geekbench6" "$payload_dir/geekbench6"
+install -m 755 "$extract_dir/geekbench_riscv64" "$payload_dir/geekbench_riscv64"
+install -m 755 "$extract_dir/geekbench_rv64gcv" "$payload_dir/geekbench_rv64gcv"
+install -m 644 "$extract_dir/geekbench.plar" "$payload_dir/geekbench.plar"
+install -m 644 "$extract_dir/geekbench-workload.plar" "$payload_dir/geekbench-workload.plar"
+install -m 755 "$WORKLOAD_DIR/run.sh" "$payload_dir/run.sh"
+mkdir -p "$PKG_DIR/etc"
+mkdir -p "$PKG_DIR/etc/default"
+printf 'GEEKBENCH_ARGS=%q\n' "${GEEKBENCH_ARGS:---cpu --iterations 1}" > "$PKG_DIR/etc/default/geekbench"
+if [ "${PROFILING:-0}" = 1 ]; then
+    printf '::sysinit:sh -c "nemu-trap 256; nemu-trap 257"\n' > "$PKG_DIR/etc/inittab"
+fi
+printf '::once:sh -c "/geekbench/run.sh; nemu-trap -1"\n' >> "$PKG_DIR/etc/inittab"

--- a/workloads/linux/geekbench6/links.txt
+++ b/workloads/linux/geekbench6/links.txt
@@ -1,0 +1,1 @@
+Geekbench-6.7.0-LinuxRISCVPreview.tar.gz https://cdn.geekbench.com/Geekbench-6.7.0-LinuxRISCVPreview.tar.gz 75b51d464a1bb96eea9921222ee1438572d34f067ef62ad864a644f8434e2df3

--- a/workloads/linux/geekbench6/rules.mk
+++ b/workloads/linux/geekbench6/rules.mk
@@ -1,0 +1,2 @@
+include workloads/linux/geekbench-common.mk
+$(eval $(call add_workload_linux_geekbench,geekbench6))

--- a/workloads/linux/geekbench6/run.sh
+++ b/workloads/linux/geekbench6/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -x
+
+if [ -r /etc/default/geekbench ]; then
+    . /etc/default/geekbench
+fi
+GEEKBENCH_ARGS="${GEEKBENCH_ARGS:---cpu --iterations 1}"
+
+mkdir -p /proc /sys
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+
+cd /geekbench
+./geekbench_riscv64 $GEEKBENCH_ARGS
+# Geekbench may fail after the benchmark when it cannot upload results, so
+# treat reaching this point as successful workload completion.
+nemu-trap 0


### PR DESCRIPTION
Add Geekbench 5 and 6 preview workloads.
Use the FPGA no-AIA DTB by default.
Support configurable profiling and Geekbench CLI args.