### PR TITLE
fix(spec2017): export variant rootfs artifacts

### DIFF
--- a/workloads/linux/spec2017/README.md
+++ b/workloads/linux/spec2017/README.md
@@ -66,15 +66,16 @@ build/images/spec2017/
   kernel/<variant>.Image
   elf/<case>.elf
   cmd/<variant>.run.sh
+  rootfs/<variant>.rootfs.cpio
   gcpt/gcpt.elf
   gcpt/gcpt.bin
   cfg/riscv-gcc15.cfg
 ```
 
 When SPEC generates multiple run commands for a case, `spec2017-images` exports
-one firmware image and one `cmd/<variant>.run.sh` per command, plus one shared
-ELF for the base case. Variants are named with the base case, command index,
-and output label, for example:
+one firmware image, one rootfs, and one `cmd/<variant>.run.sh` per command,
+plus one shared ELF for the base case. Variants are named with the base case,
+command index, and output label, for example:
 
 ```text
 perlbench_rate_refrate_00_checkspam.2500.5.25.11.150.1.1.1.1.fw_payload.bin

--- a/workloads/linux/spec2017/rules.mk
+++ b/workloads/linux/spec2017/rules.mk
@@ -203,7 +203,7 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 	SPEC2017_PROFILING="$$(SPEC2017_PROFILING)" \
 	bash "$$(abspath $$(SPEC2017_WORKLOAD_DIR))/build.sh"
 	@printf '$(SPEC2017_PROGRESS_PREFIX) Exporting $(1) split artifacts to $(SPEC2017_IMAGE_DIR)\n'
-	@mkdir -p "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs/build_elf" "$(SPEC2017_IMAGE_DIR)/stamps"
+	@mkdir -p "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs/build_elf" "$(SPEC2017_IMAGE_DIR)/stamps"
 	@if [ ! -f "$(SPEC2017_IMAGE_DIR)/cfg/$(notdir $(call spec2017_case_cfg,$(1)))" ]; then \
 		cp "$(abspath $(call spec2017_case_cfg,$(1)))" "$(SPEC2017_IMAGE_DIR)/cfg/$(notdir $(call spec2017_case_cfg,$(1)))"; \
 	fi
@@ -228,6 +228,7 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 		bash "$$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh" "$$(SPEC2017_GCPT_BIN)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$(SPEC2017_DTS_DIR)" "$$(SPEC2017_LINUX_IMAGE)" "$$$$build_dir"; \
 		cp "$$$$build_dir/package/spec/run.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
 		cp "$$(SPEC2017_LINUX_IMAGE)" "$(SPEC2017_IMAGE_DIR)/kernel/$$$$variant.Image"; \
+		cp "$$$$build_dir/rootfs.cpio" "$(SPEC2017_IMAGE_DIR)/rootfs/$$$$variant.rootfs.cpio"; \
 		cp "$$$$build_dir/fw_payload.bin" "$(SPEC2017_IMAGE_DIR)/bin/$$$$variant.fw_payload.bin"; \
 	done
 	@touch "$$@"
@@ -274,8 +275,8 @@ spec2017-images: spec2017-check-spec-config
 	@if [ -z "$(SPEC2017_IMAGE_CASES)" ]; then \
 		echo "No SPEC2017 cases selected by SPEC2017_IMAGE_INPUT=$(SPEC2017_IMAGE_INPUT) SPEC2017_IMAGE_MODE=$(SPEC2017_IMAGE_MODE)"; \
 		exit 1; \
-	fi; \
-	rm -rf "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs" "$(SPEC2017_IMAGE_DIR)/stamps"; \
+		fi; \
+		rm -rf "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs" "$(SPEC2017_IMAGE_DIR)/stamps"; \
 	total="$(words $(SPEC2017_IMAGE_CASES))"; \
 	i=0; \
 	for case in $(SPEC2017_IMAGE_CASES); do \


### PR DESCRIPTION
Copy each packaged variant's rootfs.cpio into
build/images/spec2017/rootfs/ so the exported tree keeps the initramfs next to fw_payload.bin, kernel, and run.sh.

Document the new directory in the spec2017 README.