### PR TITLE
fix(spec): unify exported image directories

### DIFF
--- a/workloads/linux/spec2006/README.md
+++ b/workloads/linux/spec2006/README.md
@@ -48,6 +48,13 @@ make spec2006-images SPEC2006_ISO=/path/to/cpu2006.iso SPEC2006_INPUT=test -jN
 make spec2006-images SPEC2006_ISO=/path/to/cpu2006.iso SPEC2006_INPUT=all -jN
 ```
 
+Export a single configured case with `BENCH`:
+
+```sh
+make spec2006-images BENCH=mcf SPEC2006_ISO=/path/to/cpu2006.iso -jN
+make spec2006-images BENCH=astar_biglakes SPEC2006_ISO=/path/to/cpu2006.iso -jN
+```
+
 Selected SPEC cases are built one by one to avoid concurrent `runspec`
 instances contending on shared temporary state inside the SPEC tool tree.
 
@@ -57,13 +64,20 @@ The export directory is organized as:
 build/images/spec2006/
   bin/<case>.fw_payload.bin
   kernel/<case>.Image
+  rootfs/<case>.rootfs.cpio
   elf/<case>.elf
+  cmd/<case>.run.sh
   gcpt/gcpt.elf
   gcpt/gcpt.bin
   cfg/<spec-cfg-name>
+  logs/build_elf/<case>.log
+  stamps/<case>.images.stamp
 ```
 
 `gcpt/` and `cfg/` are copied once per export tree, not once per case.
+
+Re-running `make spec2006-images` rebuilds the export tree so the directory
+layout and contents stay complete and consistent.
 
 Override the destination with `SPEC2006_IMAGE_DIR=/path/to/image`.
 

--- a/workloads/linux/spec2006/rules.mk
+++ b/workloads/linux/spec2006/rules.mk
@@ -37,10 +37,11 @@ SPEC2006_DTC ?= $(SPEC2006_BUILDROOT_DIR)/output/host/bin/dtc
 SPEC2006_CASE := $(if $(INPUT),$(BENCH)_$(INPUT),$(BENCH))
 SPEC2006_ALL_CASES := $(shell python3 $(SPEC2006_HELPER) --cases-config $(SPEC2006_CASE_CONFIG) --list-cases 2>/dev/null)
 SPEC2006_SELECTED_CASES := $(shell python3 $(SPEC2006_HELPER) --cases-config $(SPEC2006_CASE_CONFIG) --list-cases --input-set $(SPEC2006_INPUT) 2>/dev/null)
-SPEC2006_IMAGE_CASES := $(SPEC2006_SELECTED_CASES)
+SPEC2006_IMAGE_CASES := $(if $(BENCH),$(SPEC2006_CASE),$(SPEC2006_SELECTED_CASES))
 SPEC2006_ELF_TARGETS := $(foreach case,$(SPEC2006_SELECTED_CASES),$(SPEC2006_BUILD_DIR)/$(case)/elf/$(case).elf)
 SPEC2006_DTS_SOURCES := $(shell find $(SPEC2006_DTS_DIR) -type f 2>/dev/null)
 SPEC2006_DEFAULT_DTB_STAMP := $(SPEC2006_BUILD_DIR)/dtb.$(shell printf '%s\n' "$(SPEC2006_DEFAULT_DTB)" | sha256sum | cut -d ' ' -f 1)
+spec2006_case_image_stamp = $(SPEC2006_IMAGE_DIR)/stamps/$(1).images.stamp
 
 WORKLOAD_DIRS += $(SPEC2006_BUILD_DIR)
 
@@ -132,9 +133,9 @@ linux/$(1): $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin
 
 WORKLOAD_PHONY_TARGETS += linux/$(1)
 
-$(SPEC2006_IMAGE_DIR)/bin/$(1).fw_payload.bin: $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2006_LINUX_IMAGE)
+$(call spec2006_case_image_stamp,$(1)): $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2006_GCPT_ELF) $(SPEC2006_GCPT_BIN) $(SPEC2006_LINUX_IMAGE) | spec2006-check-spec-iso
 	@printf '$(SPEC2006_PROGRESS_PREFIX) Exporting $(1) artifacts to $(SPEC2006_IMAGE_DIR)\n'
-	@mkdir -p "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt"
+	@mkdir -p "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/logs/build_elf" "$(SPEC2006_IMAGE_DIR)/stamps"
 	@if [ ! -f "$(SPEC2006_IMAGE_DIR)/cfg/$(notdir $(SPEC2006_CFG))" ]; then \
 		printf '$(SPEC2006_PROGRESS_PREFIX) Exporting spec2006 cfg to $(SPEC2006_IMAGE_DIR)/cfg\n'; \
 		cp "$(SPEC2006_CFG)" "$(SPEC2006_IMAGE_DIR)/cfg/$(notdir $(SPEC2006_CFG))"; \
@@ -144,9 +145,13 @@ $(SPEC2006_IMAGE_DIR)/bin/$(1).fw_payload.bin: $(SPEC2006_BUILD_DIR)/$(1)/fw_pay
 		cp "$(SPEC2006_GCPT_ELF)" "$(SPEC2006_IMAGE_DIR)/gcpt/gcpt.elf"; \
 		cp "$(SPEC2006_GCPT_BIN)" "$(SPEC2006_IMAGE_DIR)/gcpt/gcpt.bin"; \
 	fi
-	@cp $(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf $(SPEC2006_IMAGE_DIR)/elf/$(1).elf
-	@cp $(SPEC2006_LINUX_IMAGE) $(SPEC2006_IMAGE_DIR)/kernel/$(1).Image
-	@cp $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2006_IMAGE_DIR)/bin/$(1).fw_payload.bin
+	@cp "$(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf" "$(SPEC2006_IMAGE_DIR)/elf/$(1).elf"
+	@cp "$(SPEC2006_BUILD_DIR)/$(1)/logs/build_elf/build.log" "$(SPEC2006_IMAGE_DIR)/logs/build_elf/$(1).log"
+	@cp "$(SPEC2006_LINUX_IMAGE)" "$(SPEC2006_IMAGE_DIR)/kernel/$(1).Image"
+	@cp "$(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio" "$(SPEC2006_IMAGE_DIR)/rootfs/$(1).rootfs.cpio"
+	@cp "$(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin" "$(SPEC2006_IMAGE_DIR)/bin/$(1).fw_payload.bin"
+	@cp "$(SPEC2006_BUILD_DIR)/$(1)/package/spec/run.sh" "$(SPEC2006_IMAGE_DIR)/cmd/$(1).run.sh"
+	@touch "$$@"
 endef
 
 $(foreach case,$(SPEC2006_ALL_CASES),$(eval $(call add_spec2006_case,$(case))))
@@ -177,15 +182,20 @@ spec2006-elfs: spec2006-check-spec-iso
 	done
 
 spec2006-images: spec2006-check-spec-iso
-	@if [ -z "$(SPEC2006_IMAGE_CASES)" ]; then \
+	@if [ -n "$(BENCH)" ] && [ -z "$(filter $(SPEC2006_CASE),$(SPEC2006_ALL_CASES))" ]; then \
+		echo "Unknown SPEC2006 case for BENCH=$(BENCH) INPUT=$(INPUT)"; \
+		exit 1; \
+	fi; \
+	if [ -z "$(SPEC2006_IMAGE_CASES)" ]; then \
 		echo "No SPEC2006 cases selected by SPEC2006_INPUT=$(SPEC2006_INPUT)"; \
 		exit 1; \
 	fi; \
+	rm -rf "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/logs" "$(SPEC2006_IMAGE_DIR)/stamps"; \
 	total="$(words $(SPEC2006_IMAGE_CASES))"; \
 	i=0; \
 	for case in $(SPEC2006_IMAGE_CASES); do \
 		i=$$((i + 1)); \
-		SPEC2006_PROGRESS_K="$$i" SPEC2006_PROGRESS_N="$$total" $(MAKE) --no-print-directory -f "$(SPEC2006_RECURSE_MAKEFILE)" GCPT_DEFAULT_DTB="$(SPEC2006_DEFAULT_DTB)" "$(SPEC2006_IMAGE_DIR)/bin/$$case.fw_payload.bin" || exit $$?; \
+		SPEC2006_PROGRESS_K="$$i" SPEC2006_PROGRESS_N="$$total" $(MAKE) --no-print-directory -f "$(SPEC2006_RECURSE_MAKEFILE)" GCPT_DEFAULT_DTB="$(SPEC2006_DEFAULT_DTB)" "$(call spec2006_case_image_stamp,$$case)" || exit $$?; \
 	done
 	@printf '[spec2006 %s/%s] Output written to %s\n' "$(words $(SPEC2006_IMAGE_CASES))" "$(words $(SPEC2006_IMAGE_CASES))" "$(abspath $(SPEC2006_IMAGE_DIR))"
 

--- a/workloads/linux/spec2006/spec2006-package.py
+++ b/workloads/linux/spec2006/spec2006-package.py
@@ -373,6 +373,16 @@ def export_elf_artifact(elf, case_name, out_dir):
     return exported_elf
 
 
+def export_build_log_artifact(build_log, out_dir):
+    if not build_log.is_file():
+        return None
+    log_dir = out_dir / "logs" / "build_elf"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    exported_log = log_dir / build_log.name
+    shutil.copy2(build_log, exported_log)
+    return exported_log
+
+
 def install_runtime_binary(elf, binary_name, pkg_dir):
     spec_root = pkg_dir / "spec"
     shutil.copy2(elf, spec_root / binary_name)
@@ -499,6 +509,7 @@ def build_elf(spec_dir, bench_dir, spec_cfg, out_dir, log_dir, cross_compile, tu
                 elf = None
             if elf is not None:
                 status(f"Reusing {bench_dir} build from {shared_dir}")
+                export_build_log_artifact(build_log, out_dir)
                 return elf, build_log
 
     if output_root.exists():
@@ -547,6 +558,7 @@ def build_elf(spec_dir, bench_dir, spec_cfg, out_dir, log_dir, cross_compile, tu
         detail = explain_missing_elf(output_root, bench_dir, tune)
         raise RuntimeError(str(exc) + detail) from exc
     write_json(metadata_path, metadata)
+    export_build_log_artifact(build_log, out_dir)
     return elf, build_log
 
 

--- a/workloads/linux/spec2017/README.md
+++ b/workloads/linux/spec2017/README.md
@@ -90,6 +90,8 @@ perlbench_rate_refrate_00_checkspam.2500.5.25.11.150.1.1.1.1.fw_payload.bin
 Useful selectors:
 
 ```sh
+make spec2017-images BENCH=mcf MODE=rate INPUT=test SPEC2017_ISO=/path/to/cpu2017.iso -jN
+make spec2017-images BENCH=mcf MODE=speed INPUT=test SPEC2017_ISO=/path/to/cpu2017.iso -jN
 make spec2017-images SPEC2017_ISO=/path/to/cpu2017.iso SPEC2017_IMAGE_INPUT=test -jN
 make spec2017-images SPEC2017_ISO=/path/to/cpu2017.iso SPEC2017_IMAGE_INPUT=all -jN
 make spec2017-images SPEC2017_ISO=/path/to/cpu2017.iso SPEC2017_IMAGE_MODE=rate -jN

--- a/workloads/linux/spec2017/rules.mk
+++ b/workloads/linux/spec2017/rules.mk
@@ -56,7 +56,7 @@ SPEC2017_BUILD_VARS_HASH := $(shell printf '%s\n' '$(SPEC2017_PROFILING)' '$(SPE
 SPEC2017_CASE := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --resolve-case --bench '$(BENCH)' --input-set '$(SPEC2017_INPUT)' --mode '$(SPEC2017_MODE)' 2>/dev/null)
 SPEC2017_ALL_CASES := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --list-cases --input-set all --mode all 2>/dev/null)
 SPEC2017_SELECTED_CASES := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --list-cases --input-set $(SPEC2017_INPUT) --mode $(SPEC2017_MODE) 2>/dev/null)
-SPEC2017_IMAGE_CASES := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --list-cases --input-set $(SPEC2017_IMAGE_INPUT) --mode $(SPEC2017_IMAGE_MODE) 2>/dev/null)
+SPEC2017_IMAGE_CASES := $(if $(BENCH),$(SPEC2017_CASE),$(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --list-cases --input-set $(SPEC2017_IMAGE_INPUT) --mode $(SPEC2017_IMAGE_MODE) 2>/dev/null))
 SPEC2017_DTS_SOURCES := $(shell find $(SPEC2017_DTS_DIR) -type f 2>/dev/null)
 
 WORKLOAD_DIRS += $(SPEC2017_BUILD_DIR)
@@ -246,7 +246,7 @@ linux/spec2017: spec2017-check-spec-config
 		echo "Cannot resolve SPEC2017 case from BENCH=$(BENCH), MODE=$(SPEC2017_MODE), INPUT=$(SPEC2017_INPUT)"; \
 		exit 1; \
 	fi
-	@$(MAKE) --no-print-directory -f "$(SPEC2017_RECURSE_MAKEFILE)" $(SPEC2017_BUILD_DIR)/$(SPEC2017_CASE)/fw_payload.bin
+	@$(MAKE) --no-print-directory -f "$(SPEC2017_RECURSE_MAKEFILE)" GCPT_DEFAULT_DTB="$(SPEC2017_DEFAULT_DTB)" $(SPEC2017_BUILD_DIR)/$(SPEC2017_CASE)/fw_payload.bin
 
 spec2017-elf: spec2017-check-spec-config
 	@if [ -z "$(BENCH)" ]; then \
@@ -272,7 +272,11 @@ spec2017-elfs: spec2017-check-spec-config
 	done
 
 spec2017-images: spec2017-check-spec-config
-	@if [ -z "$(SPEC2017_IMAGE_CASES)" ]; then \
+	@if [ -n "$(BENCH)" ] && [ -z "$(SPEC2017_CASE)" ]; then \
+		echo "Cannot resolve SPEC2017 case from BENCH=$(BENCH), MODE=$(SPEC2017_MODE), INPUT=$(SPEC2017_INPUT)"; \
+		exit 1; \
+	fi; \
+	if [ -z "$(SPEC2017_IMAGE_CASES)" ]; then \
 		echo "No SPEC2017 cases selected by SPEC2017_IMAGE_INPUT=$(SPEC2017_IMAGE_INPUT) SPEC2017_IMAGE_MODE=$(SPEC2017_IMAGE_MODE)"; \
 		exit 1; \
 		fi; \
@@ -281,7 +285,7 @@ spec2017-images: spec2017-check-spec-config
 	i=0; \
 	for case in $(SPEC2017_IMAGE_CASES); do \
 		i=$$((i + 1)); \
-		SPEC2017_PROGRESS_K="$$i" SPEC2017_PROGRESS_N="$$total" $(MAKE) --no-print-directory -f "$(SPEC2017_RECURSE_MAKEFILE)" "$(SPEC2017_IMAGE_DIR)/stamps/$$case.images.stamp" || exit $$?; \
+		SPEC2017_PROGRESS_K="$$i" SPEC2017_PROGRESS_N="$$total" $(MAKE) --no-print-directory -f "$(SPEC2017_RECURSE_MAKEFILE)" GCPT_DEFAULT_DTB="$(SPEC2017_DEFAULT_DTB)" "$(SPEC2017_IMAGE_DIR)/stamps/$$case.images.stamp" || exit $$?; \
 	done
 	@printf '[spec2017 %s/%s] Output written to %s\n' "$(words $(SPEC2017_IMAGE_CASES))" "$(words $(SPEC2017_IMAGE_CASES))" "$(abspath $(SPEC2017_IMAGE_DIR))"
 

--- a/workloads/linux/spec2026/README.md
+++ b/workloads/linux/spec2026/README.md
@@ -1,5 +1,14 @@
 # SPEC CPU2026 Linux Workload
 
+This workload prepares a writable SPEC workspace from `SPEC2026_ISO` first,
+then builds cases against that local install.
+
+Prepare the workspace:
+
+```sh
+make spec2026-prepare SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso
+```
+
 Build one case:
 
 ```sh
@@ -13,13 +22,14 @@ make spec2026-images SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso -jN
 ```
 
 Default image export mode is `rate`. Use `MODE=speed` or `MODE=all` to
-change the selected cases.
+change the selected cases. `SPEC2026_IMAGE_MODE` and `SPEC2026_IMAGE_INPUT`
+can be used independently from the single-case build selectors.
 
-Output goes to `build/images/spec2026`.
-Rate cases are written to `build/images/spec2026rate`; speed cases are written
-to `build/images/spec2026speed`.
+By default, rate images are exported under `build/images/spec2026rate/` and
+speed images under `build/images/spec2026speed/`. `SPEC2026_IMAGE_MODE=all`
+keeps the combined export under `build/images/spec2026/`.
 
-The export tree now includes:
+The export tree is:
 
 ```text
 build/images/spec2026rate/
@@ -47,5 +57,19 @@ build/images/spec2026speed/
   stamps/<case>.images.stamp
 ```
 
-Re-running `make spec2026-images` skips completed cases and resumes an
-interrupted case build through `build/linux-workloads/spec2026/_bench-builds`.
+Useful selectors:
+
+```sh
+make spec2026-images BENCH=706.stockfish_r SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso -jN
+make spec2026-images BENCH=800.pot3d_s MODE=speed SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso -jN
+make spec2026-images SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso SPEC2026_IMAGE_INPUT=test -jN
+make spec2026-images SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso SPEC2026_IMAGE_INPUT=all -jN
+make spec2026-images SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso SPEC2026_IMAGE_MODE=rate -jN
+make spec2026-images SPEC2026_ISO=/path/to/cpu2026-1.0.1.iso SPEC2026_IMAGE_MODE=all -jN
+```
+
+`SPEC2026_IMAGE_MODE=all` exports both rate and speed images into the same
+combined tree that `SPEC2026_IMAGE_DIR` points to.
+
+Re-running `make spec2026-images` rebuilds the export tree so the directory
+layout and contents stay complete and consistent.

--- a/workloads/linux/spec2026/rules.mk
+++ b/workloads/linux/spec2026/rules.mk
@@ -8,6 +8,7 @@ SPEC2026_DTS_DIR := $(SPEC2026_REPO_ROOT)/dts
 SPEC2026_BUILD_DIR ?= $(SPEC2026_REPO_ROOT)/build/linux-workloads/spec2026
 SPEC2026_CFG ?= $(SPEC2026_WORKLOAD_DIR)/riscv_gcc15_base.cfg
 SPEC2026_HELPER := $(SPEC2026_WORKLOAD_DIR)/spec2026-package.py
+SPEC2026_IMAGE_DIR ?= $(SPEC2026_REPO_ROOT)/build/images/$(if $(filter rate,$(SPEC2026_IMAGE_MODE)),spec2026rate,$(if $(filter speed,$(SPEC2026_IMAGE_MODE)),spec2026speed,spec2026))
 SPEC2026_IMAGE_RATE_DIR ?= $(SPEC2026_REPO_ROOT)/build/images/spec2026rate
 SPEC2026_IMAGE_SPEED_DIR ?= $(SPEC2026_REPO_ROOT)/build/images/spec2026speed
 SPEC2026_SOURCE_SPEC_ISO := $(SPEC2026_ISO)
@@ -42,15 +43,17 @@ SPEC2026_RATE_DTB_MIN_MEMORY_BYTES ?= 8589934592
 SPEC2026_SPEED_DTB_MIN_MEMORY_BYTES ?= 68719476736
 SPEC2026_ALL_CASES := $(shell python3 $(SPEC2026_HELPER) --list-cases --mode all 2>/dev/null)
 SPEC2026_SELECTED_CASES := $(shell python3 $(SPEC2026_HELPER) --list-cases --input-set $(SPEC2026_INPUT) --mode $(SPEC2026_MODE) 2>/dev/null)
-SPEC2026_IMAGE_CASES := $(shell python3 $(SPEC2026_HELPER) --list-cases --input-set $(SPEC2026_IMAGE_INPUT) --mode $(SPEC2026_IMAGE_MODE) 2>/dev/null)
+SPEC2026_IMAGE_CASES := $(if $(BENCH),$(BENCH),$(shell python3 $(SPEC2026_HELPER) --list-cases --input-set $(SPEC2026_IMAGE_INPUT) --mode $(SPEC2026_IMAGE_MODE) 2>/dev/null))
 SPEC2026_DTS_SOURCES := $(shell find $(SPEC2026_DTS_DIR) -type f 2>/dev/null)
+SPEC2026_CFG_HASH := $(shell if [ -f "$(abspath $(SPEC2026_CFG))" ]; then sha256sum "$(abspath $(SPEC2026_CFG))" | cut -d ' ' -f 1; else printf 'missing'; fi)
+SPEC2026_BUILD_VARS_HASH := $(shell printf '%s\n' '$(SPEC2026_INPUT)' '$(SPEC2026_TUNE)' '$(SPEC2026_JOBS)' '$(SPEC2026_CROSS_COMPILE)' | sha256sum | cut -d ' ' -f 1)
 
 spec2026_case_dtb_memory = $(if $(SPEC2026_DTB_MEMORY),$(SPEC2026_DTB_MEMORY),$(if $(filter %_s,$(1)),$(SPEC2026_SPEED_DTB_MEMORY),$(SPEC2026_RATE_DTB_MEMORY)))
 spec2026_case_dtb_profile = $(if $(SPEC2026_EXPLICIT_DEFAULT_DTB),,$(call spec2026_case_dtb_memory,$(1)))
 spec2026_case_dtb_name = $(SPEC2026_DEFAULT_DTB)$(if $(call spec2026_case_dtb_profile,$(1)),-mem$(call spec2026_case_dtb_profile,$(1)))
 spec2026_case_dtb_tag = $(subst /,_,$(call spec2026_case_dtb_name,$(1)))
 spec2026_case_dtb_min_memory_bytes = $(if $(filter %_s,$(1)),$(SPEC2026_SPEED_DTB_MIN_MEMORY_BYTES),$(SPEC2026_RATE_DTB_MIN_MEMORY_BYTES))
-spec2026_case_image_dir = $(if $(filter %_s,$(1)),$(SPEC2026_IMAGE_SPEED_DIR),$(SPEC2026_IMAGE_RATE_DIR))
+spec2026_case_image_dir = $(SPEC2026_IMAGE_DIR)
 spec2026_case_image_stamp = $(call spec2026_case_image_dir,$(1))/stamps/$(1).images.stamp
 
 WORKLOAD_DIRS += $(SPEC2026_BUILD_DIR)
@@ -100,6 +103,14 @@ $(SPEC2026_BUILD_DIR)/$(1)/download/sentinel:
 	@mkdir -p "$$(@D)"
 	@touch "$$@"
 
+$(SPEC2026_BUILD_DIR)/$(1)/cfg.$(SPEC2026_CFG_HASH).stamp: | spec2026-check-spec-iso
+	@mkdir -p "$$(@D)"
+	@printf '%s\n' "cfg=$(abspath $(SPEC2026_CFG))" > "$$@"
+
+$(SPEC2026_BUILD_DIR)/$(1)/build-vars.$(SPEC2026_BUILD_VARS_HASH).stamp:
+	@mkdir -p "$$(@D)"
+	@printf '%s\n' "input=$(SPEC2026_INPUT)" "tune=$(SPEC2026_TUNE)" "jobs=$(SPEC2026_JOBS)" "cross_compile=$(SPEC2026_CROSS_COMPILE)" > "$$@"
+
 $(SPEC2026_BUILD_DIR)/$(1)/firmware/dtb-$(call spec2026_case_dtb_tag,$(1)).stamp: spec2026-force
 	@mkdir -p "$$(@D)"
 	@printf '%s\n' \
@@ -109,7 +120,7 @@ $(SPEC2026_BUILD_DIR)/$(1)/firmware/dtb-$(call spec2026_case_dtb_tag,$(1)).stamp
 		"min_memory_bytes=$(call spec2026_case_dtb_min_memory_bytes,$(1))" > "$$@.tmp"
 	@if [ -f "$$@" ] && cmp -s "$$@.tmp" "$$@"; then rm "$$@.tmp"; else mv "$$@.tmp" "$$@"; fi
 
-$(SPEC2026_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2026_PREPARE_STAMP) $$(SPEC2026_HELPER) $$(SPEC2026_WORKLOAD_DIR)/build.sh $$(SPEC2026_CFG)
+$(SPEC2026_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2026_PREPARE_STAMP) $(SPEC2026_BUILD_DIR)/$(1)/cfg.$(SPEC2026_CFG_HASH).stamp $(SPEC2026_BUILD_DIR)/$(1)/build-vars.$(SPEC2026_BUILD_VARS_HASH).stamp $$(SPEC2026_HELPER) $$(SPEC2026_WORKLOAD_DIR)/build.sh
 	@mkdir -p "$$(dir $$@)"
 	@WORKLOAD_DIR="$$(abspath $$(SPEC2026_WORKLOAD_DIR))" \
 	WORKLOAD_BUILD_DIR="$$(abspath $(SPEC2026_BUILD_DIR)/$(1))" \
@@ -125,7 +136,7 @@ $(SPEC2026_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2026_PREPARE_STAMP) $$(SPEC2026_H
 	SPEC2026_ELF_ONLY=1 \
 	bash "$$(abspath $$(SPEC2026_WORKLOAD_DIR))/build.sh"
 
-$(SPEC2026_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2026_PREPARE_STAMP) $$(SPEC2026_HELPER) $$(SPEC2026_WORKLOAD_DIR)/build.sh $$(SPEC2026_CFG) $(SPEC2026_BUILD_DIR)/$(1)/download/sentinel $$(SPEC2026_SCRIPTS_DIR)/build-workload-linux.sh
+$(SPEC2026_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2026_PREPARE_STAMP) $(SPEC2026_BUILD_DIR)/$(1)/cfg.$(SPEC2026_CFG_HASH).stamp $(SPEC2026_BUILD_DIR)/$(1)/build-vars.$(SPEC2026_BUILD_VARS_HASH).stamp $$(SPEC2026_HELPER) $$(SPEC2026_WORKLOAD_DIR)/build.sh $(SPEC2026_BUILD_DIR)/$(1)/download/sentinel $$(SPEC2026_SCRIPTS_DIR)/build-workload-linux.sh
 	@CROSS_COMPILE="$$(SPEC2026_CROSS_COMPILE)" \
 	SPEC2026_PROGRESS_K="$$(SPEC2026_PROGRESS_K)" \
 	SPEC2026_PROGRESS_N="$$(SPEC2026_PROGRESS_N)" \
@@ -193,28 +204,21 @@ spec2026-elfs: spec2026-check-spec-iso
 	done
 
 spec2026-images: spec2026-check-spec-iso
-	@if [ -z "$(SPEC2026_IMAGE_CASES)" ]; then \
+	@if [ -n "$(BENCH)" ] && [ -z "$(filter $(BENCH),$(SPEC2026_ALL_CASES))" ]; then \
+		echo "Unknown SPEC2026 case BENCH=$(BENCH)"; \
+		exit 1; \
+	fi; \
+	if [ -z "$(SPEC2026_IMAGE_CASES)" ]; then \
 		echo "No SPEC2026 cases selected by SPEC2026_IMAGE_INPUT=$(SPEC2026_IMAGE_INPUT), SPEC2026_IMAGE_MODE=$(SPEC2026_IMAGE_MODE)"; \
 		exit 1; \
 	fi; \
+	rm -rf "$(SPEC2026_IMAGE_DIR)/bin" "$(SPEC2026_IMAGE_DIR)/kernel" "$(SPEC2026_IMAGE_DIR)/rootfs" "$(SPEC2026_IMAGE_DIR)/elf" "$(SPEC2026_IMAGE_DIR)/cmd" "$(SPEC2026_IMAGE_DIR)/cfg" "$(SPEC2026_IMAGE_DIR)/gcpt" "$(SPEC2026_IMAGE_DIR)/logs" "$(SPEC2026_IMAGE_DIR)/stamps"; \
 	total="$(words $(SPEC2026_IMAGE_CASES))"; \
 	i=0; \
 	for case in $(SPEC2026_IMAGE_CASES); do \
 		i=$$((i + 1)); \
-		case "$$case" in \
-			*_s) image_dir="$(SPEC2026_IMAGE_SPEED_DIR)" ;; \
-			*) image_dir="$(SPEC2026_IMAGE_RATE_DIR)" ;; \
-		esac; \
-		stamp="$$image_dir/stamps/$$case.images.stamp"; \
-		if [ -f "$$stamp" ] && [ -f "$$image_dir/bin/$$case.fw_payload.bin" ] && [ -f "$$image_dir/kernel/$$case.Image" ] && [ -f "$$image_dir/rootfs/$$case.rootfs.cpio" ] && [ -f "$$image_dir/elf/$$case.elf" ] && [ -f "$$image_dir/cmd/$$case.run.sh" ] && [ -f "$$image_dir/cfg/$(notdir $(SPEC2026_CFG))" ] && [ -f "$$image_dir/gcpt/gcpt.elf" ] && [ -f "$$image_dir/gcpt/gcpt.bin" ] && [ -f "$$image_dir/logs/build_elf/$$case.log" ]; then \
-			printf '[spec2026 %s/%s] Reusing exported images for %s\n' "$$i" "$$total" "$$case"; \
-			continue; \
-		fi; \
-		if [ -f "$$stamp" ]; then \
-			rm -f "$$stamp"; \
-		fi; \
-		SPEC2026_PROGRESS_K="$$i" SPEC2026_PROGRESS_N="$$total" $(MAKE) --no-print-directory -f "$(SPEC2026_RECURSE_MAKEFILE)" GCPT_DEFAULT_DTB="$(SPEC2026_DEFAULT_DTB)" "$$stamp" || exit $$?; \
+		SPEC2026_INPUT="$(SPEC2026_IMAGE_INPUT)" SPEC2026_PROGRESS_K="$$i" SPEC2026_PROGRESS_N="$$total" $(MAKE) --no-print-directory -f "$(SPEC2026_RECURSE_MAKEFILE)" GCPT_DEFAULT_DTB="$(SPEC2026_DEFAULT_DTB)" "$(call spec2026_case_image_stamp,$$case)" || exit $$?; \
 	done
-	@printf '[spec2026 %s/%s] Output written to %s and %s\n' "$(words $(SPEC2026_IMAGE_CASES))" "$(words $(SPEC2026_IMAGE_CASES))" "$(abspath $(SPEC2026_IMAGE_RATE_DIR))" "$(abspath $(SPEC2026_IMAGE_SPEED_DIR))"
+	@printf '[spec2026 %s/%s] Output written to %s\n' "$(words $(SPEC2026_IMAGE_CASES))" "$(words $(SPEC2026_IMAGE_CASES))" "$(abspath $(SPEC2026_IMAGE_DIR))"
 
 .PHONY: linux/spec2026 spec2026-check-spec-iso spec2026-prepare spec2026-elf spec2026-elfs spec2026-images spec2026-force


### PR DESCRIPTION
Align SPEC2006 and SPEC2026 image exports with the SPEC2017\nlayout so all three workloads write bin, kernel, rootfs, elf,\ncmd, cfg, gcpt, logs, and stamp artifacts consistently.\n\nAdd single-case image export support with BENCH for SPEC2006,\nSPEC2017, and SPEC2026, export SPEC2006 build logs into the image\ntree, and make SPEC2026 image builds track input-sensitive build\nstate.\n\nUpdate the SPEC2006, SPEC2017, and SPEC2026 READMEs to document\nthe unified output structure and the single-case export commands.