### PR TITLE
fix(dts): reserve gcpt memory in FPGA templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ For Linux workloads, the image assumes that execution begins at `0x80000000`, an
 
 Multiple device trees are built for each workload, each corresponds to a specific NEMU configuration. The device tree files are placed under the `dt` directory in the build output directory of that workload. The "default" device tree built into the image is `dt/xiangshan.dtb`. To replace the device tree, the following command can be used:
 
+For DTS files used with gcpt, the beginning of RAM must be reserved with a `reserved-memory` node so Linux does not allocate or map the gcpt checkpoint buffer. The XiangShan FPGA DTS templates reserve 1 MiB at `0x80000000` for this purpose.
+
 ```shell
 dd conv=notrunc bs=1024 seek=1536 if=dt/some_device.dtb of=fw_payload.bin
 ```

--- a/dts/xiangshan-fpga-noAIA-mem24g-novec.dts.in
+++ b/dts/xiangshan-fpga-noAIA-mem24g-novec.dts.in
@@ -93,6 +93,17 @@
 		reg = <0x0 0x80000000 0x6 0x00000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA-mem24g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-mem24g.dts.in
@@ -94,6 +94,17 @@
 		reg = <0x0 0x80000000 0x6 0x00000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA-mem64g-novec.dts.in
+++ b/dts/xiangshan-fpga-noAIA-mem64g-novec.dts.in
@@ -93,6 +93,17 @@
 		reg = <0x0 0x80000000 0x10 0x00000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA-mem64g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-mem64g.dts.in
@@ -94,6 +94,17 @@
 		reg = <0x0 0x80000000 0x10 0x00000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA-mem8g-novec.dts.in
+++ b/dts/xiangshan-fpga-noAIA-mem8g-novec.dts.in
@@ -94,6 +94,17 @@
 		reg = <0x0 0x80000000 0x2 0x00000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA-mem8g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-mem8g.dts.in
@@ -95,6 +95,17 @@
 		reg = <0x0 0x80000000 0x2 0x00000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA-novec.dts.in
+++ b/dts/xiangshan-fpga-noAIA-novec.dts.in
@@ -94,6 +94,17 @@
 		reg = <0x0 0x80000000 0x0 0x80000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/dts/xiangshan-fpga-noAIA.dts.in
+++ b/dts/xiangshan-fpga-noAIA.dts.in
@@ -95,6 +95,17 @@
 		reg = <0x0 0x80000000 0x0 0x80000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
 	soc {
 		#address-cells = <2>;
 		#size-cells = <2>;


### PR DESCRIPTION
## Summary
- Reserve 1 MiB at `0x80000000` in XiangShan FPGA DTS templates for the gcpt checkpoint buffer.
- Add `reserved-memory` nodes with `no-map` so Linux does not allocate or map the gcpt buffer.
- Document the gcpt DTS reservation requirement in the Linux workloads README.