### PR TITLE
feat(gapbs): size per-case trial counts to a runtime target

### DIFF
--- a/workloads/linux/gapbs/README.md
+++ b/workloads/linux/gapbs/README.md
@@ -3,20 +3,37 @@
 NEMU SimPoint checkpoint images for the
 [GAP Benchmark Suite](https://github.com/sbeamer/gapbs). Each workload is one
 `kernel × graph` pair: a static, single-threaded GAPBS kernel that loads a
-pre-serialized reference graph and runs a single trial. There are 18 cases —
+pre-serialized reference graph and runs one or more trials. There are 18 cases —
 the cartesian product of six kernels and three graphs.
 
 | kernel | graph file    | arguments |
 |--------|---------------|-----------|
-| bfs    | `<graph>.sg`  | `-n 1` |
-| sssp   | `<graph>.wsg` | `-d <delta> -n 1` (road `50000`; twitter/web `2`) |
+| bfs    | `<graph>.sg`  | `-n <trials>` |
+| sssp   | `<graph>.wsg` | `-d <delta> -n <trials>` (delta: road `50000`; twitter/web `2`) |
 | pr     | `<graph>.sg`  | `-i 1000 -t 1e-4 -n 1` |
 | cc     | `<graph>.sg`  | `-n 1` |
-| bc     | `<graph>.sg`  | `-i 1 -n 1` |
+| bc     | `<graph>.sg`  | `-i 1 -n <trials>` |
 | tc     | `<graph>U.sg` | `-n 1` |
 
 Graphs: `road`, `twitter`, `web`. Cases are named `<kernel>_<graph>`
 (e.g. `bfs_road`, `sssp_web`).
+
+## Trials
+
+`bfs`, `sssp`, and `bc` pick a new random source each trial, so more trials
+sample more sources. Their trial count is sized per case (`num_trials` in
+`gapbs-package.py`) so every such case runs for roughly the same time — cheap
+cases get many trials, expensive ones get few:
+
+| kernel | road | twitter | web |
+|--------|-----:|--------:|----:|
+| bfs    |   33 |      13 |   2 |
+| sssp   |   39 |       2 |   1 |
+| bc     |   26 |       2 |   1 |
+
+`pr`, `cc`, and `tc` are source-independent — every trial is identical work, so
+they stay at a single trial regardless. Raise or lower `TARGET_TRIAL_SECONDS`
+to rebalance.
 
 ## Building
 

--- a/workloads/linux/gapbs/gapbs-package.py
+++ b/workloads/linux/gapbs/gapbs-package.py
@@ -10,17 +10,40 @@ SUFFIX = {"bfs": ".sg", "pr": ".sg", "cc": ".sg", "bc": ".sg",
           "sssp": ".wsg", "tc": "U.sg"}
 SSSP_DELTA = {"road": "50000", "twitter": "2", "web": "2"}
 
+# Only bfs/sssp/bc pick a new random source per trial, so only they gain from
+# more trials; pr/cc/tc repeat identical work and stay at a single trial.
+SOURCE_DEPENDENT = {"bfs", "sssp", "bc"}
+
+# Measured single-trial guest runtime (seconds) from the n=1 checkpoint run:
+# (graph-load "Read Time", one-kernel "Trial Time"). Trials are sized so each
+# source-dependent case runs for roughly TARGET_TRIAL_SECONDS, balancing runtime
+# across cases; adjust the target to trade source coverage against cost.
+_TRIAL_CALIB = {
+    ("bfs",  "road"): (16, 24),  ("bfs",  "twitter"): (251, 43),  ("bfs",  "web"): (316, 298),
+    ("sssp", "road"): (23, 20),  ("sssp", "twitter"): (474, 170), ("sssp", "web"): (609, 207),
+    ("bc",   "road"): (16, 30),  ("bc",   "twitter"): (251, 301), ("bc",   "web"): (316, 358),
+}
+TARGET_TRIAL_SECONDS = 800
+MAX_TRIALS = 64
+
+def num_trials(kernel, graph):
+    if kernel not in SOURCE_DEPENDENT:
+        return 1
+    read, trial = _TRIAL_CALIB[(kernel, graph)]
+    return max(1, min(MAX_TRIALS, round((TARGET_TRIAL_SECONDS - read) / trial)))
+
 # initramfs newc cpio caps each file at 4 GiB (2**32); split any graph at/above it.
 SPLIT_THRESHOLD = 4 * 1024**3
 PART_SIZE = "3G"   # each part is well under the 4 GiB cpio limit
 
 def kernel_args(kernel, graph):
-    if kernel == "bfs":  return ["-n", "1"]
-    if kernel == "cc":   return ["-n", "1"]
-    if kernel == "pr":   return ["-i", "1000", "-t", "1e-4", "-n", "1"]
-    if kernel == "bc":   return ["-i", "1", "-n", "1"]
-    if kernel == "sssp": return ["-d", SSSP_DELTA[graph], "-n", "1"]
-    if kernel == "tc":   return ["-n", "1"]
+    n = str(num_trials(kernel, graph))
+    if kernel == "bfs":  return ["-n", n]
+    if kernel == "cc":   return ["-n", n]
+    if kernel == "pr":   return ["-i", "1000", "-t", "1e-4", "-n", n]
+    if kernel == "bc":   return ["-i", "1", "-n", n]
+    if kernel == "sssp": return ["-d", SSSP_DELTA[graph], "-n", n]
+    if kernel == "tc":   return ["-n", n]
     raise RuntimeError(f"unknown kernel {kernel}")
 
 def all_cases():


### PR DESCRIPTION
## What

  Size the per-case trial count of the source-dependent GAPBS kernels
  (`bfs`, `sssp`, `bc`) to a common runtime target, instead of always running a
  single trial. Source-independent kernels (`pr`, `cc`, `tc`) stay at one trial.

  ## Why

  `bfs`, `sssp`, and `bc` pick a fresh random source on each trial, so running
  more trials samples more sources and makes a case more representative. `pr`,
  `cc`, and `tc` repeat identical work every trial, so extra trials add cost with
  no coverage. A fixed `-n 1` therefore under-samples the cheap source-dependent
  cases and would over-spend if bumped uniformly.

  ## How

  `gapbs-package.py` gains a `num_trials(kernel, graph)` helper. For the
  source-dependent kernels it derives the count from measured single-trial guest
  runtimes (`_TRIAL_CALIB`: graph-load "Read Time" + one-kernel "Trial Time") so
  each case runs for roughly `TARGET_TRIAL_SECONDS` (default 800 s, capped at
  `MAX_TRIALS`). Cheap cases get many trials, expensive ones stay at one:

  | kernel | road | twitter | web |
  |--------|-----:|--------:|----:|
  | bfs    |   33 |      13 |   2 |
  | sssp   |   39 |       2 |   1 |
  | bc     |   26 |       2 |   1 |

  `TARGET_TRIAL_SECONDS` is the single knob to trade source coverage against cost.
  `README.md` documents the behaviour and the resulting table.

  ## Scope

  Two files, `workloads/linux/gapbs/{README.md, gapbs-package.py}`. No change to
  `build.sh`, `rules.mk`, the graph `source` pin, or any other workload. Below
  4 GiB nothing else is affected. Builds on the merged gapbs workload family
  (#26).
