### PR TITLE
fix(spec2006): Rebuild on CFG changes and avoid gamess GCC ICE

### DIFF
--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul1.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul1.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m1 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m1 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul2.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul2.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m2 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m2 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul4.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul4.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m4 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m4 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul8.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul8.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/rules.mk
+++ b/workloads/linux/spec2006/rules.mk
@@ -40,6 +40,7 @@ SPEC2006_SELECTED_CASES := $(shell python3 $(SPEC2006_HELPER) --cases-config $(S
 SPEC2006_IMAGE_CASES := $(if $(BENCH),$(SPEC2006_CASE),$(SPEC2006_SELECTED_CASES))
 SPEC2006_ELF_TARGETS := $(foreach case,$(SPEC2006_SELECTED_CASES),$(SPEC2006_BUILD_DIR)/$(case)/elf/$(case).elf)
 SPEC2006_DTS_SOURCES := $(shell find $(SPEC2006_DTS_DIR) -type f 2>/dev/null)
+SPEC2006_CFG_HASH := $(shell if [ -f "$(abspath $(SPEC2006_CFG))" ]; then sha256sum "$(abspath $(SPEC2006_CFG))" | cut -d ' ' -f 1; else printf 'missing'; fi)
 SPEC2006_DEFAULT_DTB_STAMP := $(SPEC2006_BUILD_DIR)/dtb.$(shell printf '%s\n' "$(SPEC2006_DEFAULT_DTB)" | sha256sum | cut -d ' ' -f 1)
 spec2006_case_image_stamp = $(SPEC2006_IMAGE_DIR)/stamps/$(1).images.stamp
 
@@ -80,12 +81,21 @@ $(SPEC2006_DEFAULT_DTB_STAMP):
 	@rm -f "$(SPEC2006_BUILD_DIR)"/dtb.*
 	@touch "$@"
 
+spec2006-force:
+
 define add_spec2006_case
 $(SPEC2006_BUILD_DIR)/$(1)/download/sentinel:
 	@mkdir -p $$(@D)
 	@touch $$@
 
-$(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2006_PREPARE_STAMP) $$(SPEC2006_HELPER) $$(SPEC2006_WORKLOAD_DIR)/build.sh $$(SPEC2006_CASE_CONFIG) $$(SPEC2006_CFG)
+$(SPEC2006_BUILD_DIR)/$(1)/cfg.stamp: spec2006-force
+	@mkdir -p "$$(@D)"
+	@printf '%s\n' \
+		"cfg=$$(abspath $$(SPEC2006_CFG))" \
+		"hash=$$(SPEC2006_CFG_HASH)" > "$$@.tmp"
+	@if [ -f "$$@" ] && cmp -s "$$@.tmp" "$$@"; then rm "$$@.tmp"; else mv "$$@.tmp" "$$@"; fi
+
+$(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUILD_DIR)/$(1)/cfg.stamp $$(SPEC2006_HELPER) $$(SPEC2006_WORKLOAD_DIR)/build.sh $$(SPEC2006_CASE_CONFIG)
 	@mkdir -p "$$(dir $$@)"
 	@WORKLOAD_DIR="$$(abspath $$(SPEC2006_WORKLOAD_DIR))" \
 	WORKLOAD_BUILD_DIR="$$(abspath $(SPEC2006_BUILD_DIR)/$(1))" \
@@ -105,7 +115,7 @@ $(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2006_PREPARE_STAMP) $$(SPEC2006_H
 	SPEC2006_ELF_ONLY=1 \
 	bash "$$(abspath $$(SPEC2006_WORKLOAD_DIR))/build.sh"
 
-$(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2006_PREPARE_STAMP) $$(SPEC2006_HELPER) $$(SPEC2006_WORKLOAD_DIR)/build.sh $$(SPEC2006_CASE_CONFIG) $$(SPEC2006_CFG) $(SPEC2006_BUILD_DIR)/$(1)/download/sentinel $$(SPEC2006_SCRIPTS_DIR)/build-workload-linux.sh
+$(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUILD_DIR)/$(1)/cfg.stamp $$(SPEC2006_HELPER) $$(SPEC2006_WORKLOAD_DIR)/build.sh $$(SPEC2006_CASE_CONFIG) $(SPEC2006_BUILD_DIR)/$(1)/download/sentinel $$(SPEC2006_SCRIPTS_DIR)/build-workload-linux.sh
 	@CROSS_COMPILE="$$(SPEC2006_CROSS_COMPILE)" \
 	SPEC2006_PROGRESS_K="$$(SPEC2006_PROGRESS_K)" \
 	SPEC2006_PROGRESS_N="$$(SPEC2006_PROGRESS_N)" \
@@ -199,4 +209,4 @@ spec2006-images: spec2006-check-spec-iso
 	done
 	@printf '[spec2006 %s/%s] Output written to %s\n' "$(words $(SPEC2006_IMAGE_CASES))" "$(words $(SPEC2006_IMAGE_CASES))" "$(abspath $(SPEC2006_IMAGE_DIR))"
 
-.PHONY: linux/spec2006 spec2006-check-spec-iso spec2006-prepare spec2006-elf spec2006-elfs spec2006-images
+.PHONY: linux/spec2006 spec2006-check-spec-iso spec2006-force spec2006-prepare spec2006-elf spec2006-elfs spec2006-images


### PR DESCRIPTION
## Summary

- Track the active SPEC CPU2006 configuration with a per-case `cfg.stamp`.
  This rebuilds the ELF, rootfs, and firmware when the selected CFG changes,
  including when switching back to a previously used CFG.
- Disable GCC SLP vectorization only for `416.gamess` in the GCC 15.2
  `rva23u64` LMUL1/2/4/8 configuration to avoid the compiler ICE.
- Keep LTO, regular vectorization, and LMUL m8 enabled for `416.gamess`.
