### PR TITLE
fix(spec2006): Disable slp-vectorize to avoid gamess GCC ICE

### DIFF
--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul1.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul1.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m1 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m1 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul2.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul2.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m2 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m2 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul4.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul4.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m4 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m4 -mrvv-vector-bits=zvl -fno-strict-aliasing

--- a/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul8.cfg
+++ b/workloads/linux/spec2006/configs/gcc15.2-linux-riscv64-rva23u64_lmul8.cfg
@@ -125,6 +125,9 @@ fp=base=default:
     EXTRA_LIBS      = $(JEMALLOC_LIBS)
     EXTRA_LDFLAGS   = $(STATIC_LDFLAGS)
 
+416.gamess=base=default=default:
+FOPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto -ffp-contract=fast -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing -fno-tree-slp-vectorize
+
 int=peak=default:
     COPTIMIZE       = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing
     CXXOPTIMIZE     = -static -O3 -march=$(MARCH) -ffast-math -flto  -ffp-contract=off -std=c++98 -ftree-vectorize -mrvv-max-lmul=m8 -mrvv-vector-bits=zvl -fno-strict-aliasing


### PR DESCRIPTION
## Summary

- Disable GCC SLP vectorization only for `416.gamess` in the GCC 15.2 `rva23u64_LMUL1/2/4/8` configuration to avoid the compiler ICE.