### PR TITLE
feat(linux): support validated multi-hart firmware layouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,24 @@ all: workloads
 
 MULTIHART ?= 0
 HARTS ?= 2
-LINUX_MULTIHART_DEFAULT_DTB := xiangshan-fpga-noAIA-$(HARTS)hart-mem8g
-LINUX_DEFAULT_DTB := $(if $(DEFAULT_DTB),$(DEFAULT_DTB),$(if $(filter 1,$(MULTIHART)),$(LINUX_MULTIHART_DEFAULT_DTB),))
+LINUX_DEFAULT_DTB := $(if $(DEFAULT_DTB),$(DEFAULT_DTB),)
+LINUX_ROOTFS_BUILD_VARS_HASH := $(shell printf '%s\n' \
+	'multihart=$(if $(filter 1,$(MULTIHART)),1,0)' \
+	'harts=$(if $(filter 1,$(MULTIHART)),$(HARTS),1)' | sha256sum | cut -d ' ' -f 1)
+LINUX_FIRMWARE_BUILD_VARS_HASH := $(shell printf '%s\n' \
+	'multihart=$(if $(filter 1,$(MULTIHART)),1,0)' \
+	'harts=$(if $(filter 1,$(MULTIHART)),$(HARTS),1)' \
+	'default_dtb=$(if $(DEFAULT_DTB),$(DEFAULT_DTB),xiangshan)' | sha256sum | cut -d ' ' -f 1)
+
+MULTIHART_SUPPORTED_HARTS := $(shell seq 2 128)
+ifeq ($(filter 1,$(MULTIHART)),1)
+ifeq ($(filter $(HARTS),$(MULTIHART_SUPPORTED_HARTS)),)
+$(error HARTS must be an integer in the range 2..128 when MULTIHART=1)
+endif
+ifeq ($(strip $(DEFAULT_DTB)),)
+$(error DEFAULT_DTB must be specified when MULTIHART=1; use the complete DTS basename without .dts.in)
+endif
+endif
 
 # Download buildroot
 BUILDROOT_DIR := build/buildroot
@@ -32,7 +48,7 @@ GCPT_IMPLEMENTATION := $(if $(filter 1,$(MULTIHART)),libcheckpoint,alpha)
 GCPT_SOURCE_DIR := $(if $(filter 1,$(MULTIHART)),bootloader/LibCheckpoint,bootloader/LibCheckpointAlpha)
 GCPT_BUILD_DIR := $(if $(filter 1,$(MULTIHART)),build/LibCheckpoint,build/LibCheckpointAlpha)
 GCPT_BIN := $(GCPT_BUILD_DIR)/build/gcpt.bin
-GCPT_DEFAULT_DTB ?= $(if $(DEFAULT_DTB),$(DEFAULT_DTB),$(if $(filter 1,$(MULTIHART)),$(LINUX_MULTIHART_DEFAULT_DTB),xiangshan))
+GCPT_DEFAULT_DTB ?= $(if $(DEFAULT_DTB),$(DEFAULT_DTB),xiangshan)
 GCPT_CONFIGURE_MODE := $(if $(filter 1,$(MULTIHART)),dual_core,normal)
 GCPT_CONFIG_STAMP := $(if $(filter 1,$(MULTIHART)),build/LibCheckpoint-config/mode.$(GCPT_CONFIGURE_MODE),build/LibCheckpointAlpha-config/dtb.$(shell printf '%s\n' "$(GCPT_DEFAULT_DTB)" | sha256sum | cut -d ' ' -f 1))
 GCPT_SOURCES := $(if $(filter 1,$(MULTIHART)),$(shell find $(GCPT_SOURCE_DIR) -path '*/.git' -prune -o -path '*/tests' -prune -o -type f -print 2>/dev/null),$(shell find $(GCPT_SOURCE_DIR) -path '*/.git' -prune -o -type f -print 2>/dev/null))
@@ -50,10 +66,12 @@ $(GCPT_BIN): scripts/build-gcpt.sh $(TOOLCHAIN_WRAPPER) $(GCPT_SOURCES) $(GCPT_D
 	bash scripts/build-gcpt.sh $(GCPT_SOURCE_DIR) $(GCPT_BUILD_DIR)
 
 # Build OpenSBI
-SBI_BUILD_DIR := build/opensbi
+SBI_BUILD_DIR := $(if $(filter 1,$(MULTIHART)),build/opensbi-multihart,build/opensbi)
 SBI_BIN := $(SBI_BUILD_DIR)/build/platform/generic/firmware/fw_jump.bin
 $(SBI_BIN): scripts/build-sbi.sh bootloader/opensbi.config $(TOOLCHAIN_WRAPPER)
-	CROSS_COMPILE="$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" bash scripts/build-sbi.sh bootloader/opensbi build/opensbi
+	CROSS_COMPILE="$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
+	MULTIHART="$(MULTIHART)" \
+	bash scripts/build-sbi.sh bootloader/opensbi $(SBI_BUILD_DIR)
 
 define add_workload_linux
 # Download files
@@ -62,7 +80,12 @@ build/linux-workloads/$(1)/download/sentinel: $$(shell find $$(abspath workloads
 	bash scripts/download-files.sh workloads/linux/$(1) build/linux-workloads/$(1)/download
 
 # Build and pack workload
-build/linux-workloads/$(1)/rootfs.cpio: $$(shell find $$(abspath workloads/linux/$(1))) $(TOOLCHAIN_WRAPPER) build/linux-workloads/$(1)/download/sentinel scripts/build-workload-linux.sh scripts/package-multihart-rootfs.py
+build/linux-workloads/$(1)/rootfs-vars.$(LINUX_ROOTFS_BUILD_VARS_HASH).stamp:
+	mkdir -p "$$(@D)"
+	rm -f "$$(@D)"/rootfs-vars.*.stamp
+	touch "$$@"
+
+build/linux-workloads/$(1)/rootfs.cpio: $$(shell find $$(abspath workloads/linux/$(1))) $(TOOLCHAIN_WRAPPER) build/linux-workloads/$(1)/download/sentinel scripts/build-workload-linux.sh scripts/package-multihart-rootfs.py build/linux-workloads/$(1)/rootfs-vars.$(LINUX_ROOTFS_BUILD_VARS_HASH).stamp
 	CROSS_COMPILE="$$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
 	SYSROOT_DIR="$$(abspath $(BUILDROOT_DIR)/output/staging)" \
 	BUILDROOT_DIR="$$(abspath $(BUILDROOT_DIR))" \
@@ -71,11 +94,18 @@ build/linux-workloads/$(1)/rootfs.cpio: $$(shell find $$(abspath workloads/linux
 	bash scripts/build-workload-linux.sh workloads/linux/$(1) build/linux-workloads/$(1)
 
 # Build all-in-one firmware
-build/linux-workloads/$(1)/fw_payload.bin: $$(shell find $$(abspath dts)) $(GCPT_BIN) dts/xiangshan.dts.in scripts/build-sbi.sh scripts/build-firmware-linux.sh build/linux-workloads/$(1)/rootfs.cpio $(LINUX_IMAGE) build/opensbi/build/platform/generic/firmware/fw_jump.bin
+build/linux-workloads/$(1)/firmware-vars.$(LINUX_FIRMWARE_BUILD_VARS_HASH).stamp:
+	mkdir -p "$$(@D)"
+	rm -f "$$(@D)"/firmware-vars.*.stamp
+	touch "$$@"
+
+build/linux-workloads/$(1)/fw_payload.bin: $$(shell find $$(abspath dts)) $(GCPT_BIN) dts/xiangshan.dts.in scripts/build-sbi.sh scripts/build-firmware-linux.sh build/linux-workloads/$(1)/rootfs.cpio $(LINUX_IMAGE) $(SBI_BIN) build/linux-workloads/$(1)/firmware-vars.$(LINUX_FIRMWARE_BUILD_VARS_HASH).stamp
 	CROSS_COMPILE="$$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
 	DTC="$$(abspath $(BUILDROOT_DIR)/output/host/bin)/dtc" \
 	DEFAULT_DTB="$(LINUX_DEFAULT_DTB)" \
-	bash scripts/build-firmware-linux.sh $(GCPT_BIN) build/opensbi dts $(LINUX_IMAGE) build/linux-workloads/$(1)
+	MULTIHART="$$(MULTIHART)" \
+	HARTS="$$(HARTS)" \
+	bash scripts/build-firmware-linux.sh $(GCPT_BIN) $(SBI_BUILD_DIR) dts $(LINUX_IMAGE) build/linux-workloads/$(1)
 
 linux/$(1): build/linux-workloads/$(1)/fw_payload.bin
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LINUX_FIRMWARE_BUILD_VARS_HASH := $(shell printf '%s\n' \
 	'harts=$(if $(filter 1,$(MULTIHART)),$(HARTS),1)' \
 	'default_dtb=$(if $(DEFAULT_DTB),$(DEFAULT_DTB),xiangshan)' | sha256sum | cut -d ' ' -f 1)
 
-MULTIHART_SUPPORTED_HARTS := $(shell seq 2 128)
+MULTIHART_SUPPORTED_HARTS = $(shell seq 2 128)
 ifeq ($(filter 1,$(MULTIHART)),1)
 ifeq ($(filter $(HARTS),$(MULTIHART_SUPPORTED_HARTS)),)
 $(error HARTS must be an integer in the range 2..128 when MULTIHART=1)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ $(LINUX_IMAGE): $(TOOLCHAIN_WRAPPER) br2-external/configs/nemu_defconfig br2-ext
 
 # Build GCPT. Single-core firmware keeps LibCheckpointAlpha; LibCheckpoint is
 # used for the QEMU multi-hart checkpoint format.
+SBI_BUILD_DIR := $(if $(filter 1,$(MULTIHART)),build/opensbi-multihart,build/opensbi)
+SBI_BIN := $(SBI_BUILD_DIR)/build/platform/generic/firmware/fw_jump.bin
+
 GCPT_IMPLEMENTATION := $(if $(filter 1,$(MULTIHART)),libcheckpoint,alpha)
 GCPT_SOURCE_DIR := $(if $(filter 1,$(MULTIHART)),bootloader/LibCheckpoint,bootloader/LibCheckpointAlpha)
 GCPT_BUILD_DIR := $(if $(filter 1,$(MULTIHART)),build/LibCheckpoint,build/LibCheckpointAlpha)
@@ -57,17 +60,16 @@ $(GCPT_CONFIG_STAMP):
 	mkdir -p "$(@D)"
 	rm -f $(if $(filter 1,$(MULTIHART)),build/LibCheckpoint-config/mode.*,build/LibCheckpointAlpha-config/dtb.*)
 	touch "$@"
-$(GCPT_BIN): scripts/build-gcpt.sh $(TOOLCHAIN_WRAPPER) $(GCPT_SOURCES) $(GCPT_DTS_SOURCES) $(GCPT_CONFIG_STAMP)
+$(GCPT_BIN): scripts/build-gcpt.sh $(TOOLCHAIN_WRAPPER) $(GCPT_SOURCES) $(GCPT_DTS_SOURCES) $(GCPT_CONFIG_STAMP) $(if $(filter 1,$(MULTIHART)),$(SBI_BIN),)
 	CROSS_COMPILE="$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
 	GCPT_IMPLEMENTATION="$(GCPT_IMPLEMENTATION)" \
 	GCPT_CONFIGURE_MODE="$(GCPT_CONFIGURE_MODE)" \
+	GCPT_PAYLOAD_PATH="$(if $(filter 1,$(MULTIHART)),$(abspath $(SBI_BIN)),)" \
 	DEFAULT_DTB="$(GCPT_DEFAULT_DTB)" \
 	DTS_TEMPLATE_DIR="$(abspath dts)" \
 	bash scripts/build-gcpt.sh $(GCPT_SOURCE_DIR) $(GCPT_BUILD_DIR)
 
 # Build OpenSBI
-SBI_BUILD_DIR := $(if $(filter 1,$(MULTIHART)),build/opensbi-multihart,build/opensbi)
-SBI_BIN := $(SBI_BUILD_DIR)/build/platform/generic/firmware/fw_jump.bin
 $(SBI_BIN): scripts/build-sbi.sh bootloader/opensbi.config $(TOOLCHAIN_WRAPPER)
 	CROSS_COMPILE="$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
 	MULTIHART="$(MULTIHART)" \

--- a/README.md
+++ b/README.md
@@ -29,19 +29,21 @@ SPEC Linux workloads can also build multi-hart rootfs images:
 ```shell
 make linux/spec2006 BENCH=astar INPUT=biglakes \
   SPEC2006_ISO=/path/to/cpu2006.iso \
-  MULTIHART=1 HARTS=2 -jN
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
 ```
 
 `MULTIHART=1` creates per-hart workload directories, uses `/bin/nemu-trap` to
 send codes 256 and 257 before each benchmark copy and code 258 after it
-returns, and selects
-`xiangshan-fpga-noAIA-<HARTS>hart-mem8g` as the default DTB when `DEFAULT_DTB`
-is not set. Its matching template must exist in `dts/`; the build fails rather
-than generating a missing multi-hart DTS.
+returns, and requires `DEFAULT_DTB` to be set to the complete DTS basename.
+Its matching template must exist in `dts/`; the build fails rather than
+guessing a memory profile or generating a missing multi-hart DTS.
 
 Single-core firmware uses LibCheckpointAlpha. Multi-core firmware uses
 LibCheckpoint to restore QEMU multi-hart checkpoints. Set `HARTS` to match
-the checkpoint and the selected device-tree template.
+the checkpoint and the selected device-tree template; supported multi-hart
+counts are 2 through 128. All multi-hart images reserve the 131 MiB checkpoint
+window `[0x80300000, 0x88600000)` and load Linux at `0x88600000`.
 
 ## Workload Compatibility
 
@@ -64,15 +66,31 @@ To create a compressed tarball containing all built workloads, run `make tarball
 
 ### Linux Workloads
 
-For Linux workloads, the image assumes that execution begins at `0x80000000`, and the image is loaded into a continuous memory starting from that address. The image contains the following content:
+For Linux workloads, the image assumes that execution begins at `0x80000000`, and the image is loaded into a continuous memory starting from that address. A single-core image contains:
 
 | Offset  | Content                       |
 |---------|-------------------------------|
-| 0.0 MiB | LibCheckpointAlpha (single-core) / LibCheckpoint (multi-core) |
+| 0.0 MiB | LibCheckpointAlpha            |
 | 1.0 MiB | OpenSBI                       |
 | 1.5 MiB | device tree                   |
 | 2.0 MiB | Linux kernel                  |
 | --      | initramfs containing workload |
+
+A multi-hart image uses the fixed QEMU checkpoint layout:
+
+| Physical address range | Size | Content |
+|------------------------|------|---------|
+| `0x80000000–0x800fffff` | 1 MiB | LibCheckpoint recovery program |
+| `0x80100000–0x802fffff` | 2 MiB | OpenSBI, with the DTB at `0x80200000` |
+| `0x80300000–0x885fffff` | 131 MiB | Checkpoint state window (`no-map`) |
+| `0x88600000+` | -- | Linux kernel, followed by the MiB-aligned initramfs |
+
+For OpenSBI, this is `FW_TEXT_START=0x80100000` plus
+`FW_PAYLOAD_OFFSET=0x08500000`, giving a Linux entry address of
+`0x88600000`.
+
+The canonical single-core and multi-hart DTS memory maps, including DRAM
+profiles and DTS selection examples, are in [dts/README.md](dts/README.md#single-core-physical-memory-map).
 
 Multiple device trees are built for each workload, each corresponds to a specific NEMU configuration. The device tree files are placed under the `dt` directory in the build output directory of that workload. The "default" device tree built into the image is `dt/xiangshan.dtb`. To replace the device tree, the following command can be used:
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,8 @@ A multi-hart image uses the fixed QEMU checkpoint layout:
 | `0x80300000–0x885fffff` | 131 MiB | Checkpoint state window (`no-map`) |
 | `0x88600000+` | -- | Linux kernel, followed by the MiB-aligned initramfs |
 
-For OpenSBI, this is `FW_TEXT_START=0x80100000` plus
-`FW_PAYLOAD_OFFSET=0x08500000`, giving a Linux entry address of
-`0x88600000`.
+For OpenSBI, the multi-hart image uses `FW_TEXT_START=0x80100000`,
+`FW_JUMP_ADDR=0x88600000`, and `FW_JUMP_FDT_ADDR=0x80200000`.
 
 The canonical single-core and multi-hart DTS memory maps, including DRAM
 profiles and DTS selection examples, are in [dts/README.md](dts/README.md#single-core-physical-memory-map).

--- a/dts/README.md
+++ b/dts/README.md
@@ -19,10 +19,70 @@ These parameters are replaced with the corresponding values when building the wo
 - `xiangshan-fpga-noAIA-mem24g-novec.dts.in`: XiangShan FPGA DTS without vector extensions, with a 24 GiB memory profile.
 - `xiangshan-fpga-noAIA-mem64g-novec.dts.in`: XiangShan FPGA DTS without vector extensions, with a 64 GiB memory profile.
 
-Multi-hart XiangShan builds select a template named
-`xiangshan-fpga-noAIA-<HARTS>hart-mem8g.dts.in` from this directory.
-Add the matching template before building a new hart count; the build fails if
-the selected template does not exist.
+Multi-hart XiangShan builds require the user to select a complete DTS basename
+with `DEFAULT_DTB`; the build no longer assumes a `mem8g` suffix. For example,
+`DEFAULT_DTB=xiangshan-fpga-noAIA-32hart-mem64g` selects
+`xiangshan-fpga-noAIA-32hart-mem64g.dts.in`. The matching template must exist;
+the build fails if it does not.
+
+## Single-Core Physical Memory Map
+
+Single-core images use `MULTIHART=0` and LibCheckpointAlpha. They keep the
+original compact placement below; the multi-hart checkpoint-state reservation
+and the `0x88600000` kernel address do not apply:
+
+| Physical address / range | Size or offset | Assignment |
+|-------------------------|----------------|------------|
+| `0x80000000–0x800fffff` | 1 MiB | LibCheckpointAlpha checkpoint-recovery program; reserved as `no-map` in the DTS |
+| `0x80100000` | +1 MiB | OpenSBI firmware starts here |
+| `0x80180000` | +1.5 MiB | Device tree placed here by firmware assembly |
+| `0x80200000` and above | +2 MiB | Linux kernel image, then the MiB-aligned initramfs |
+
+The single-core firmware packer uses `DTB_OFFSET_KB=1536`,
+`SBI_OFFSET_KB=1024`, and `KERNEL_OFFSET_MB=2`. The initramfs address is
+computed from the actual kernel size and starts at the next MiB boundary. The
+selected single-core DTS supplies the DRAM capacity; no fixed 8 GiB or 64 GiB
+profile is imposed by this layout.
+
+## Multi-Hart Physical Memory Map
+
+All `MULTIHART=1` images use the same physical placement, regardless of the
+selected DRAM capacity or hart count. The image is loaded at `0x80000000`:
+
+| Physical range | Size | Assignment |
+|----------------|------|------------|
+| `0x80000000–0x800fffff` | 1 MiB | LibCheckpoint/GCPT checkpoint-recovery program |
+| `0x80100000–0x802fffff` | 2 MiB | OpenSBI firmware; the selected DTB is placed at `0x80200000` |
+| `0x80300000–0x885fffff` | 131 MiB | `no-map` checkpoint register-state reservation |
+| `0x88600000` and above | — | Linux kernel image, then the MiB-aligned initramfs |
+
+The checkpoint reservation is `[0x80300000, 0x88600000)`. LibCheckpoint uses
+one 1 MiB state slot per hart and currently allocates startup/restore storage
+for at most 128 harts. Therefore the build accepts `HARTS=2..128`; the 131 MiB
+window includes the slots plus alignment headroom before Linux.
+
+The kernel address is derived from the OpenSBI placement:
+
+```text
+FW_TEXT_START     = 0x80100000
+FW_PAYLOAD_OFFSET = 0x08500000
+Linux entry       = 0x88600000
+```
+
+The unified addresses do not force a single DRAM size. The repository's
+standard templates retain these profiles:
+
+| Template | DRAM |
+|----------|------|
+| `xiangshan-fpga-noAIA-2hart-mem8g` | 8 GiB |
+| `xiangshan-fpga-noAIA-32hart-mem64g` | 64 GiB |
+
+Select the complete template basename explicitly when building, for example:
+
+```sh
+make linux/hello MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g
+```
 
 ## Generate Multi-Hart XiangShan DTS
 
@@ -37,13 +97,18 @@ python3 scripts/generate-xiangshan-multihart-dts.py \
   --output dts/xiangshan-fpga-noAIA-2hart-mem8g.dts.in
 ```
 
-`--harts` must be at least 2. The generator copies the CPU node for each hart,
+`--harts` must be in the range 2 through 128. The generator copies the CPU node for each hart,
 extends the CLINT, PLIC, and debug interrupt contexts, and applies the NEMU
 UARTLITE and PLIC settings. It normalizes every generated CPU to
-`riscv,isa = "rv64imafdc"`.
+`riscv,isa = "rv64imafdc"`. Generated multi-hart templates reserve the fixed
+131 MiB checkpoint window `[0x80300000, 0x88600000)`.
 
 The build does not invoke this generator automatically. Run it and review the
 result before building with the corresponding `HARTS` value.
 
-The generator can create other topologies, but multi-core firmware uses
-LibCheckpoint, whose QEMU restorer currently supports only `HARTS=2`.
+The generator can create other topologies. For multi-core firmware, set
+`HARTS` in the range 2 through 128 to match both the generated template and the
+QEMU checkpoint, and pass that template through `DEFAULT_DTB`. Every
+multi-hart image uses DTB address `0x80200000` and kernel address
+`0x88600000`; the fixed placement keeps the 131 MiB checkpoint window at
+`0x80300000` clear of the boot payload.

--- a/dts/README.md
+++ b/dts/README.md
@@ -64,9 +64,9 @@ window includes the slots plus alignment headroom before Linux.
 The kernel address is derived from the OpenSBI placement:
 
 ```text
-FW_TEXT_START     = 0x80100000
-FW_PAYLOAD_OFFSET = 0x08500000
-Linux entry       = 0x88600000
+FW_TEXT_START   = 0x80100000
+FW_JUMP_ADDR    = 0x88600000
+FW_JUMP_FDT_ADDR = 0x80200000
 ```
 
 The unified addresses do not force a single DRAM size. The repository's

--- a/dts/xiangshan-fpga-noAIA-2hart-mem8g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-2hart-mem8g.dts.in
@@ -121,6 +121,12 @@
 			no-map;
 			reg = <0x0 0x80000000 0x0 0x100000>;
 		};
+
+		/* Keep the 131 MiB QEMU checkpoint window out of Linux memory. */
+		checkpoint: checkpoint@80300000 {
+			no-map;
+			reg = <0x0 0x80300000 0x0 0x08300000>;
+		};
 	};
 
 	soc {

--- a/dts/xiangshan-fpga-noAIA-32hart-mem64g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-32hart-mem64g.dts.in
@@ -1,0 +1,752 @@
+/dts-v1/;
+
+/ {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    compatible = "xiangshan,nemu-board";
+    model = "XiangShan";
+
+    chosen {
+        bootargs = "earlycon=sbi console=hvc0 unaligned_scalar_speed=slow unaligned_vector_speed=slow rcupdate.rcu_cpu_stall_suppress=1";
+        linux,initrd-start = <INITRAMFS_BEGIN_HI INITRAMFS_BEGIN_LO>;
+        linux,initrd-end = <INITRAMFS_END_HI INITRAMFS_END_LO>;
+        rng-seed = /bits/ 8 <0x58 0x49 0x41 0x4e 0x47 0x53 0x48 0x41 0x4e 0x5f 0x4e 0x45 0x4d 0x55 0x5f 0x42 0x4f 0x41 0x52 0x44 0x5f 0x52 0x41 0x4e 0x44 0x4f 0x4d 0x5f 0x53 0x45 0x45 0x44>;
+
+        opensbi-config {
+            compatible = "opensbi,config";
+            cold-boot-harts = <&cpu0>;
+        };
+    };
+
+    memory@80000000 {
+        device_type = "memory";
+        reg = <0x0 0x80000000 0x10 0x0>;
+    };
+
+    cpus {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        timebase-frequency = <10000000>;
+
+        cpu0: cpu@0 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <0>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu0_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu1: cpu@1 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <1>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu1_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu2: cpu@2 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <2>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu2_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu3: cpu@3 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <3>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu3_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu4: cpu@4 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <4>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu4_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu5: cpu@5 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <5>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu5_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu6: cpu@6 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <6>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu6_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu7: cpu@7 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <7>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu7_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu8: cpu@8 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <8>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu8_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu9: cpu@9 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <9>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu9_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu10: cpu@10 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <10>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu10_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu11: cpu@11 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <11>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu11_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu12: cpu@12 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <12>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu12_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu13: cpu@13 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <13>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu13_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu14: cpu@14 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <14>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu14_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu15: cpu@15 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <15>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu15_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu16: cpu@16 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <16>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu16_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu17: cpu@17 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <17>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu17_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu18: cpu@18 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <18>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu18_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu19: cpu@19 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <19>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu19_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu20: cpu@20 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <20>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu20_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu21: cpu@21 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <21>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu21_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu22: cpu@22 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <22>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu22_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu23: cpu@23 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <23>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu23_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu24: cpu@24 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <24>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu24_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu25: cpu@25 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <25>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu25_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu26: cpu@26 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <26>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu26_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu27: cpu@27 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <27>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu27_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu28: cpu@28 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <28>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu28_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu29: cpu@29 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <29>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu29_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu30: cpu@30 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <30>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu30_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+        cpu31: cpu@31 {
+            compatible = "riscv";
+            device_type = "cpu";
+            mmu-type = "riscv,sv39";
+            reg = <31>;
+            riscv,cbom-block-size = <64>;
+            riscv,cbop-block-size = <64>;
+            riscv,cboz-block-size = <64>;
+            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa-base = "rv64i";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+
+            cpu31_intc: interrupt-controller {
+                #interrupt-cells = <1>;
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+            };
+        };
+
+    };
+
+    clint: clint@38000000 {
+        compatible = "riscv,clint0";
+        reg = <0x0 0x38000000 0x0 0x10000>;
+        interrupts-extended = <&cpu0_intc 3>, <&cpu0_intc 7>,
+                              <&cpu1_intc 3>, <&cpu1_intc 7>,
+                              <&cpu2_intc 3>, <&cpu2_intc 7>,
+                              <&cpu3_intc 3>, <&cpu3_intc 7>,
+                              <&cpu4_intc 3>, <&cpu4_intc 7>,
+                              <&cpu5_intc 3>, <&cpu5_intc 7>,
+                              <&cpu6_intc 3>, <&cpu6_intc 7>,
+                              <&cpu7_intc 3>, <&cpu7_intc 7>,
+                              <&cpu8_intc 3>, <&cpu8_intc 7>,
+                              <&cpu9_intc 3>, <&cpu9_intc 7>,
+                              <&cpu10_intc 3>, <&cpu10_intc 7>,
+                              <&cpu11_intc 3>, <&cpu11_intc 7>,
+                              <&cpu12_intc 3>, <&cpu12_intc 7>,
+                              <&cpu13_intc 3>, <&cpu13_intc 7>,
+                              <&cpu14_intc 3>, <&cpu14_intc 7>,
+                              <&cpu15_intc 3>, <&cpu15_intc 7>,
+                              <&cpu16_intc 3>, <&cpu16_intc 7>,
+                              <&cpu17_intc 3>, <&cpu17_intc 7>,
+                              <&cpu18_intc 3>, <&cpu18_intc 7>,
+                              <&cpu19_intc 3>, <&cpu19_intc 7>,
+                              <&cpu20_intc 3>, <&cpu20_intc 7>,
+                              <&cpu21_intc 3>, <&cpu21_intc 7>,
+                              <&cpu22_intc 3>, <&cpu22_intc 7>,
+                              <&cpu23_intc 3>, <&cpu23_intc 7>,
+                              <&cpu24_intc 3>, <&cpu24_intc 7>,
+                              <&cpu25_intc 3>, <&cpu25_intc 7>,
+                              <&cpu26_intc 3>, <&cpu26_intc 7>,
+                              <&cpu27_intc 3>, <&cpu27_intc 7>,
+                              <&cpu28_intc 3>, <&cpu28_intc 7>,
+                              <&cpu29_intc 3>, <&cpu29_intc 7>,
+                              <&cpu30_intc 3>, <&cpu30_intc 7>,
+                              <&cpu31_intc 3>, <&cpu31_intc 7>;
+    };
+
+    plic: plic@3c000000 {
+        compatible = "riscv,plic0";
+        reg = <0x0 0x3c000000 0x0 0x4000000>;
+        #interrupt-cells = <1>;
+        interrupt-controller;
+        interrupts-extended = <&cpu0_intc 11>, <&cpu0_intc 9>,
+                              <&cpu1_intc 11>, <&cpu1_intc 9>,
+                              <&cpu2_intc 11>, <&cpu2_intc 9>,
+                              <&cpu3_intc 11>, <&cpu3_intc 9>,
+                              <&cpu4_intc 11>, <&cpu4_intc 9>,
+                              <&cpu5_intc 11>, <&cpu5_intc 9>,
+                              <&cpu6_intc 11>, <&cpu6_intc 9>,
+                              <&cpu7_intc 11>, <&cpu7_intc 9>,
+                              <&cpu8_intc 11>, <&cpu8_intc 9>,
+                              <&cpu9_intc 11>, <&cpu9_intc 9>,
+                              <&cpu10_intc 11>, <&cpu10_intc 9>,
+                              <&cpu11_intc 11>, <&cpu11_intc 9>,
+                              <&cpu12_intc 11>, <&cpu12_intc 9>,
+                              <&cpu13_intc 11>, <&cpu13_intc 9>,
+                              <&cpu14_intc 11>, <&cpu14_intc 9>,
+                              <&cpu15_intc 11>, <&cpu15_intc 9>,
+                              <&cpu16_intc 11>, <&cpu16_intc 9>,
+                              <&cpu17_intc 11>, <&cpu17_intc 9>,
+                              <&cpu18_intc 11>, <&cpu18_intc 9>,
+                              <&cpu19_intc 11>, <&cpu19_intc 9>,
+                              <&cpu20_intc 11>, <&cpu20_intc 9>,
+                              <&cpu21_intc 11>, <&cpu21_intc 9>,
+                              <&cpu22_intc 11>, <&cpu22_intc 9>,
+                              <&cpu23_intc 11>, <&cpu23_intc 9>,
+                              <&cpu24_intc 11>, <&cpu24_intc 9>,
+                              <&cpu25_intc 11>, <&cpu25_intc 9>,
+                              <&cpu26_intc 11>, <&cpu26_intc 9>,
+                              <&cpu27_intc 11>, <&cpu27_intc 9>,
+                              <&cpu28_intc 11>, <&cpu28_intc 9>,
+                              <&cpu29_intc 11>, <&cpu29_intc 9>,
+                              <&cpu30_intc 11>, <&cpu30_intc 9>,
+                              <&cpu31_intc 11>, <&cpu31_intc 9>;
+        riscv,max-priority = <7>;
+        riscv,ndev = <64>;
+    };
+
+
+    reserved-memory {
+        #address-cells = <2>;
+        #size-cells = <2>;
+        ranges;
+        resv0@80000000 {
+            reg = <0x0 0x80000000 0x0 0x100000>;
+            no-map;
+        };
+        resv1@80300000 {
+            /* Keep the 131 MiB QEMU checkpoint window out of Linux memory. */
+            reg = <0x0 0x80300000 0x0 0x08300000>;
+            no-map;
+        };
+    };
+
+    soc {
+        #address-cells = <2>;
+        #size-cells = <2>;
+        compatible = "simple-bus";
+        ranges;
+
+        serial@40600000 {
+            compatible = "xlnx,xps-uartlite-1.00.a";
+            reg = <0x0 0x40600000 0x0 0x1000>;
+            interrupts-extended = <&plic 3>;
+            current-speed = <115200>;
+            xlnx,data-bits = <8>;
+            xlnx,use-parity = <0>;
+        };
+
+    };
+
+};

--- a/scripts/build-firmware-linux.sh
+++ b/scripts/build-firmware-linux.sh
@@ -7,14 +7,37 @@ DTS_TEMPLATE_DIR="$(realpath "$3")"
 KERNEL_IMAGE="$(realpath "$4")"
 WORKLOAD_BUILD_DIR="$(realpath "$5")"
 CPIO_ARCHIVE="$WORKLOAD_BUILD_DIR/rootfs.cpio"
-DEFAULT_DTB="${DEFAULT_DTB:-xiangshan}"
+DEFAULT_DTB="${DEFAULT_DTB:-}"
 DTB_MEMORY_PROFILE="${DTB_MEMORY_PROFILE:-}"
 DTB_MIN_MEMORY_BYTES="${DTB_MIN_MEMORY_BYTES:-}"
+HARTS="${HARTS:-2}"
+readonly MULTIHART_MAX_HARTS=128
+readonly MULTIHART_KERNEL_OFFSET_MB=134
 
 MEM_BEGIN=$(( 0x80000000 ))
 DTB_OFFSET_KB=1536
+DTB_MAX_SIZE_KB=512
 SBI_OFFSET_KB=1024
 KERNEL_OFFSET_MB=2
+
+if [ "${MULTIHART:-0}" = 1 ]; then
+    if [ -z "$DEFAULT_DTB" ]; then
+        echo "DEFAULT_DTB must be specified when MULTIHART=1; use the complete DTS basename without .dts.in" >&2
+        exit 1
+    fi
+    case "$HARTS" in
+        ''|*[!0-9]*) echo "HARTS must be an integer in the range 2..$MULTIHART_MAX_HARTS" >&2; exit 1 ;;
+    esac
+    if [ "$HARTS" -lt 2 ] || [ "$HARTS" -gt "$MULTIHART_MAX_HARTS" ]; then
+        echo "HARTS must be an integer in the range 2..$MULTIHART_MAX_HARTS" >&2
+        exit 1
+    fi
+    DTB_OFFSET_KB=2048
+    DTB_MAX_SIZE_KB=1024
+    KERNEL_OFFSET_MB="$MULTIHART_KERNEL_OFFSET_MB"
+elif [ -z "$DEFAULT_DTB" ]; then
+    DEFAULT_DTB=xiangshan
+fi
 
 KILOBYTE=1024
 MEGABYTE=$(( 1024*1024 ))
@@ -33,7 +56,7 @@ INITRAMFS_END_LO=$(printf "0x%x" $(( INITRAMFS_END_ADDR & 0xffffffff )))
 
 # Build device tree files
 DTC="${DTC:-dtc}"
-dtb_memory_size_bytes() {
+dtb_memory_range_bytes() {
     local dts_file="$1"
     local cells
     cells="$(
@@ -53,7 +76,7 @@ dtb_memory_size_bytes() {
                     }
                 }
                 if (count >= 4) {
-                    print values[3], values[4]
+                    print values[1], values[2], values[3], values[4]
                     exit
                 }
             }
@@ -63,23 +86,129 @@ dtb_memory_size_bytes() {
         return 1
     fi
     set -- $cells
-    local high="$1"
-    local low="$2"
-    printf '%s\n' $(( high * 4294967296 + low ))
+    local begin_high="$1"
+    local begin_low="$2"
+    local size_high="$3"
+    local size_low="$4"
+    printf '%s %s\n' \
+        $(( begin_high * 4294967296 + begin_low )) \
+        $(( size_high * 4294967296 + size_low ))
 }
 
-check_dtb_memory_size() {
+check_dtb_memory_layout() {
     local dts_file="$1"
     local min_bytes="$2"
+    local memory_range
+    local memory_begin
     local memory_bytes
-    if ! memory_bytes="$(dtb_memory_size_bytes "$dts_file")"; then
+    local memory_end_addr
+    if ! memory_range="$(dtb_memory_range_bytes "$dts_file")"; then
         echo "Cannot determine memory size from DTS: $dts_file" >&2
         exit 1
     fi
-    if [ "$memory_bytes" -lt "$min_bytes" ]; then
+    read -r memory_begin memory_bytes <<< "$memory_range"
+    if [ "$memory_begin" -ne "$MEM_BEGIN" ]; then
+        printf 'DTS memory must begin at 0x80000000: found 0x%x in %s\n' \
+            "$memory_begin" "$dts_file" >&2
+        exit 1
+    fi
+    if [ -n "$min_bytes" ] && [ "$memory_bytes" -lt "$min_bytes" ]; then
         echo "DTS memory is too small: $dts_file describes $memory_bytes bytes, need at least $min_bytes bytes" >&2
         exit 1
     fi
+    memory_end_addr=$(( memory_begin + memory_bytes ))
+    if [ "$INITRAMFS_END_ADDR" -gt "$memory_end_addr" ]; then
+        printf 'Firmware image exceeds DTS memory: image ends at 0x%x, memory ends at 0x%x in %s\n' \
+            "$INITRAMFS_END_ADDR" "$memory_end_addr" "$dts_file" >&2
+        exit 1
+    fi
+}
+
+check_multihart_cpu_count() {
+    local dts_file="$1"
+    local expected_harts="$2"
+    local actual_harts
+    actual_harts="$(grep -Ec 'device_type[[:space:]]*=[[:space:]]*"cpu"' "$dts_file" || true)"
+    if [ "$actual_harts" -ne "$expected_harts" ]; then
+        echo "DTS hart count mismatch: expected $expected_harts, found $actual_harts in $dts_file" >&2
+        exit 1
+    fi
+}
+
+check_multihart_checkpoint_reservation() {
+    local dts_file="$1"
+    if ! awk '
+        /@80300000[[:space:]]*\{/ {
+            in_node = 1
+            found_node = 1
+            has_reg = 0
+            has_no_map = 0
+            next
+        }
+        in_node {
+            if ($0 ~ /reg[[:space:]]*=[[:space:]]*<[[:space:]]*0x0[[:space:]]+0x80300000[[:space:]]+0x0[[:space:]]+0x08300000[[:space:]]*>[[:space:]]*;/) {
+                has_reg = 1
+            }
+            if ($0 ~ /no-map[[:space:]]*;/) {
+                has_no_map = 1
+            }
+            if ($0 ~ /^[[:space:]]*};/) {
+                exit !(has_reg && has_no_map)
+            }
+        }
+        END {
+            if (!found_node) {
+                exit 1
+            }
+        }
+    ' "$dts_file"; then
+        echo "DTS checkpoint reservation missing or invalid: expected no-map [0x80300000, 0x88600000) in $dts_file" >&2
+        exit 1
+    fi
+}
+
+check_image_component_size() {
+    local component="$1"
+    local file="$2"
+    local max_bytes="$3"
+    local actual_bytes
+    actual_bytes="$(stat -c%s "$file")"
+    if [ "$actual_bytes" -gt "$max_bytes" ]; then
+        echo "$component image is too large: maximum $max_bytes bytes, found $actual_bytes bytes in $file" >&2
+        exit 1
+    fi
+}
+
+check_gcpt_image_size() {
+    local file="$1"
+    local max_bytes="$2"
+    local actual_bytes
+    local fallback_bytes
+    actual_bytes="$(stat -c%s "$file")"
+    if [ "$actual_bytes" -le "$max_bytes" ]; then
+        return
+    fi
+
+    # Both checkpoint implementations link a no-payload fallback at exactly
+    # 1 MiB. In a combined image external OpenSBI occupies that address, so
+    # accept only their known fallback signatures and omit them from the
+    # packed GCPT slot.
+    if [ "${MULTIHART:-0}" = 1 ] && \
+        [ "$actual_bytes" -eq $(( max_bytes + 8 )) ]; then
+        fallback_bytes="$(od -An -tx1 -j "$max_bytes" -N8 "$file" | tr -d '[:space:]')"
+        if [ "$fallback_bytes" = 1305100067800000 ]; then
+            return
+        fi
+    elif [ "${MULTIHART:-0}" != 1 ] && \
+        [ "$actual_bytes" -eq $(( max_bytes + 24 )) ]; then
+        fallback_bytes="$(od -An -tx1 -j "$max_bytes" -N24 "$file" | tr -d '[:space:]')"
+        if [ "$fallback_bytes" = 730050106ff0dfff13000000130000001300000000000000 ]; then
+            return
+        fi
+    fi
+
+    echo "GCPT image is too large: maximum $max_bytes bytes, found $actual_bytes bytes in $file" >&2
+    exit 1
 }
 
 build-dtb() {
@@ -137,11 +266,17 @@ if ! [ -f "$DEFAULT_DTS_FILE" ]; then
     echo "Default device tree source not found: $DEFAULT_DTS_FILE" >&2
     exit 1
 fi
-if [ -n "$DTB_MIN_MEMORY_BYTES" ]; then
-    check_dtb_memory_size "$DEFAULT_DTS_FILE" "$DTB_MIN_MEMORY_BYTES"
+if [ "${MULTIHART:-0}" = 1 ]; then
+    check_multihart_cpu_count "$DEFAULT_DTS_FILE" "$HARTS"
+    check_multihart_checkpoint_reservation "$DEFAULT_DTS_FILE"
 fi
-dd if="$STARTUP_FILE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" status=none
+check_dtb_memory_layout "$DEFAULT_DTS_FILE" "$DTB_MIN_MEMORY_BYTES"
+SBI_IMAGE="$SBI_BUILD_DIR/build/platform/generic/firmware/fw_jump.bin"
+check_gcpt_image_size "$STARTUP_FILE" $(( SBI_OFFSET_KB * KILOBYTE ))
+check_image_component_size OpenSBI "$SBI_IMAGE" $(( (DTB_OFFSET_KB - SBI_OFFSET_KB) * KILOBYTE ))
+check_image_component_size DTB "$DEFAULT_DTB_FILE" $(( DTB_MAX_SIZE_KB * KILOBYTE ))
+dd if="$STARTUP_FILE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$KILOBYTE" count="$SBI_OFFSET_KB" status=none
 dd if="$DEFAULT_DTB_FILE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$KILOBYTE" seek="$DTB_OFFSET_KB" conv=notrunc status=none
-dd if="$SBI_BUILD_DIR/build/platform/generic/firmware/fw_jump.bin" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$KILOBYTE" seek="$SBI_OFFSET_KB" conv=notrunc status=none
+dd if="$SBI_IMAGE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$KILOBYTE" seek="$SBI_OFFSET_KB" conv=notrunc status=none
 dd if="$KERNEL_IMAGE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$MEGABYTE" seek="$KERNEL_OFFSET_MB" conv=notrunc status=none
 dd if="$CPIO_ARCHIVE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$MEGABYTE" seek="$INITRAMFS_OFFSET_MB" conv=notrunc status=none

--- a/scripts/build-firmware-linux.sh
+++ b/scripts/build-firmware-linux.sh
@@ -182,11 +182,24 @@ check_image_component_size() {
 check_gcpt_image_size() {
     local file="$1"
     local max_bytes="$2"
+    local payload_file="${3:-}"
     local actual_bytes
     local fallback_bytes
+    local payload_bytes
     actual_bytes="$(stat -c%s "$file")"
     if [ "$actual_bytes" -le "$max_bytes" ]; then
         return
+    fi
+
+    # Multi-hart LibCheckpoint may carry the same fw_jump image that is
+    # placed externally at the 1 MiB boundary in the final image. Keep the
+    # embedded copy in gcpt.bin, while still packing the original layout.
+    if [ -n "$payload_file" ] && [ -f "$payload_file" ]; then
+        payload_bytes="$(stat -c%s "$payload_file")"
+        if [ "$actual_bytes" -eq $(( max_bytes + payload_bytes )) ] && \
+            tail -c +$(( max_bytes + 1 )) "$file" | cmp -s - "$payload_file"; then
+            return
+        fi
     fi
 
     # Both checkpoint implementations link a no-payload fallback at exactly
@@ -272,7 +285,11 @@ if [ "${MULTIHART:-0}" = 1 ]; then
 fi
 check_dtb_memory_layout "$DEFAULT_DTS_FILE" "$DTB_MIN_MEMORY_BYTES"
 SBI_IMAGE="$SBI_BUILD_DIR/build/platform/generic/firmware/fw_jump.bin"
-check_gcpt_image_size "$STARTUP_FILE" $(( SBI_OFFSET_KB * KILOBYTE ))
+if [ "${MULTIHART:-0}" = 1 ]; then
+    check_gcpt_image_size "$STARTUP_FILE" $(( SBI_OFFSET_KB * KILOBYTE )) "$SBI_IMAGE"
+else
+    check_gcpt_image_size "$STARTUP_FILE" $(( SBI_OFFSET_KB * KILOBYTE ))
+fi
 check_image_component_size OpenSBI "$SBI_IMAGE" $(( (DTB_OFFSET_KB - SBI_OFFSET_KB) * KILOBYTE ))
 check_image_component_size DTB "$DEFAULT_DTB_FILE" $(( DTB_MAX_SIZE_KB * KILOBYTE ))
 dd if="$STARTUP_FILE" of="$WORKLOAD_BUILD_DIR/fw_payload.bin" bs="$KILOBYTE" count="$SBI_OFFSET_KB" status=none

--- a/scripts/build-gcpt.sh
+++ b/scripts/build-gcpt.sh
@@ -6,6 +6,7 @@ GCPT_BUILD_DIR="$(realpath "$2")"
 BUILD_DIR="$(dirname "$GCPT_BUILD_DIR")"
 GCPT_IMPLEMENTATION="${GCPT_IMPLEMENTATION:-alpha}"
 GCPT_CONFIGURE_MODE="${GCPT_CONFIGURE_MODE:-normal}"
+GCPT_PAYLOAD_PATH="${GCPT_PAYLOAD_PATH:-${3:-}}"
 
 extract_clint_mmio() {
     local dts_template_dir="$1"
@@ -39,6 +40,9 @@ extract_clint_mmio() {
 mkdir -p "$BUILD_DIR"
 rm -rf "$GCPT_BUILD_DIR"
 cp -r "$GCPT_SOURCE_DIR" "$GCPT_BUILD_DIR"
+# Source worktrees may contain ignored build output. Never reuse it when the
+# configure mode or embedded payload changes.
+rm -rf "$GCPT_BUILD_DIR/build"
 
 case "$GCPT_IMPLEMENTATION" in
     alpha)
@@ -58,7 +62,15 @@ case "$GCPT_IMPLEMENTATION" in
         esac
         (
             cd "$GCPT_BUILD_DIR"
-            bash ./configure "--mode=$GCPT_CONFIGURE_MODE"
+            configure_args=("--mode=$GCPT_CONFIGURE_MODE")
+            if [ -n "$GCPT_PAYLOAD_PATH" ]; then
+                if ! [ -f "$GCPT_PAYLOAD_PATH" ]; then
+                    echo "GCPT payload not found: $GCPT_PAYLOAD_PATH" >&2
+                    exit 1
+                fi
+                configure_args+=("--gcpt-payload=$GCPT_PAYLOAD_PATH")
+            fi
+            bash ./configure "${configure_args[@]}"
             # LibCheckpoint is freestanding, while the Buildroot toolchain
             # defaults to stack protection and PIE.
             CFLAGS="${CFLAGS:-} -fno-stack-protector -fno-PIE" make LDFLAGS="-no-pie"

--- a/scripts/build-sbi.sh
+++ b/scripts/build-sbi.sh
@@ -4,6 +4,13 @@ set -e
 SBI_SOURCE_DIR="$(realpath "$1")"
 SBI_BUILD_DIR="$(realpath "$2")"
 BUILD_DIR="$(dirname "$SBI_BUILD_DIR")"
+FW_JUMP_ADDR=0x80200000
+FW_JUMP_FDT_ADDR=0x80180000
+
+if [ "${MULTIHART:-0}" = 1 ]; then
+    FW_JUMP_ADDR=0x88600000
+    FW_JUMP_FDT_ADDR=0x80200000
+fi
 
 # prepare OpenSBI source
 mkdir -p "$BUILD_DIR"
@@ -14,4 +21,4 @@ cp "$SBI_SOURCE_DIR/../opensbi.config" "$SBI_BUILD_DIR/platform/generic/configs/
 # Build OpenSBI
 cd "$SBI_BUILD_DIR"
 patch -p1 < "$SBI_SOURCE_DIR/../opensbi.patch"
-make PLATFORM=generic FW_JUMP=y FW_TEXT_START=0x80100000 FW_JUMP_ADDR=0x80200000 FW_JUMP_FDT_ADDR=0x80180000
+make PLATFORM=generic FW_JUMP=y FW_TEXT_START=0x80100000 FW_JUMP_ADDR="$FW_JUMP_ADDR" FW_JUMP_FDT_ADDR="$FW_JUMP_FDT_ADDR"

--- a/scripts/generate-xiangshan-multihart-dts.py
+++ b/scripts/generate-xiangshan-multihart-dts.py
@@ -5,6 +5,14 @@ from pathlib import Path
 
 
 MULTIHART_RISCV_ISA = "rv64imafdc"
+MAX_HARTS = 128
+CHECKPOINT_RESERVED_NODE = """
+
+		/* Keep the 131 MiB QEMU checkpoint window out of Linux memory. */
+		checkpoint: checkpoint@80300000 {
+			no-map;
+			reg = <0x0 0x80300000 0x0 0x08300000>;
+		};"""
 CPU_ISA_PROPERTIES = re.compile(
     r'\t\t\triscv,isa = "[^"]+";\n'
     r'\t\t\triscv,isa-base = "[^"]+";\n'
@@ -19,8 +27,8 @@ def positive_harts(value):
         harts = int(value, 0)
     except ValueError as exc:
         raise argparse.ArgumentTypeError("harts must be an integer") from exc
-    if harts < 2:
-        raise argparse.ArgumentTypeError("harts must be at least 2")
+    if not 2 <= harts <= MAX_HARTS:
+        raise argparse.ArgumentTypeError(f"harts must be in the range 2..{MAX_HARTS}")
     return harts
 
 
@@ -121,6 +129,17 @@ def sanitize_nemu_uart_comments(text):
     )
 
 
+def add_checkpoint_reserved_memory(text):
+    if "checkpoint@80300000" in text:
+        return text
+
+    start, end = extract_node(text, "\treserved-memory {")
+    close = text.rfind("\n\t};", start, end)
+    if close == -1:
+        raise RuntimeError("reserved-memory node does not have the expected closing brace")
+    return text[:close] + CHECKPOINT_RESERVED_NODE + text[close:]
+
+
 def render(base_text, harts):
     start, end = extract_node(base_text, "\t\tcpu0: cpu@0 {")
     cpu0_node = normalize_cpu_isa(base_text[start:end])
@@ -142,6 +161,7 @@ def render(base_text, harts):
     text = align_nemu_plic(text)
     text = replace_fpga_uart_with_nemu_uartlite(text)
     text = sanitize_nemu_uart_comments(text)
+    text = add_checkpoint_reserved_memory(text)
     return text
 
 

--- a/scripts/generate-xiangshan-multihart-dts.py
+++ b/scripts/generate-xiangshan-multihart-dts.py
@@ -130,10 +130,10 @@ def sanitize_nemu_uart_comments(text):
 
 
 def add_checkpoint_reserved_memory(text):
-    if "checkpoint@80300000" in text:
+    start, end = extract_node(text, "\treserved-memory {")
+    if re.search(r"@80300000\s*\{", text[start:end]):
         return text
 
-    start, end = extract_node(text, "\treserved-memory {")
     close = text.rfind("\n\t};", start, end)
     if close == -1:
         raise RuntimeError("reserved-memory node does not have the expected closing brace")

--- a/scripts/package-multihart-rootfs.py
+++ b/scripts/package-multihart-rootfs.py
@@ -4,13 +4,16 @@ import shutil
 from pathlib import Path
 
 
+MAX_HARTS = 128
+
+
 def positive_harts(value):
     try:
         harts = int(value, 0)
     except ValueError as exc:
         raise argparse.ArgumentTypeError("HARTS must be an integer") from exc
-    if harts < 2:
-        raise argparse.ArgumentTypeError("HARTS must be at least 2")
+    if not 2 <= harts <= MAX_HARTS:
+        raise argparse.ArgumentTypeError(f"HARTS must be in the range 2..{MAX_HARTS}")
     return harts
 
 

--- a/workloads/linux/spec2006/README.md
+++ b/workloads/linux/spec2006/README.md
@@ -67,13 +67,14 @@ make linux/spec2006 BENCH=astar INPUT=biglakes \
 
 ## Build a multi-hart workload
 
-Add `MULTIHART=1 HARTS=2`. The current LibCheckpoint QEMU restorer supports
-exactly two guest harts:
+Add `MULTIHART=1 HARTS=<count>`, where `<count>` matches the QEMU checkpoint
+and the selected device-tree template. Supported counts are 2 through 128:
 
 ```sh
 make linux/spec2006 BENCH=astar INPUT=biglakes \
   SPEC2006_ISO=/path/to/cpu2006.iso \
-  MULTIHART=1 HARTS=2 -jN
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
 ```
 
 The package step creates one SPEC tree per hart:
@@ -91,15 +92,9 @@ starting that hart's benchmark copy with `SPEC_ROOT=/specX`, then uses
 `/bin/nemu-trap 258` after it returns. The launcher uses `taskset -c X` for
 CPU binding.
 
-When `DEFAULT_DTB` is omitted, `MULTIHART=1` selects:
-
-```text
-xiangshan-fpga-noAIA-<HARTS>hart-mem8g
-```
-
-The selected template must exist at
-`dts/xiangshan-fpga-noAIA-<HARTS>hart-mem8g.dts.in`; firmware assembly
-fails if it is missing.
+When `MULTIHART=1`, `DEFAULT_DTB` must be the complete DTS basename, including
+the desired memory profile. The corresponding `dts/<DEFAULT_DTB>.dts.in`
+template must exist; firmware assembly fails if it is missing.
 
 Selected SPEC cases are built one by one to avoid concurrent `runspec`
 instances contending on shared temporary state inside the SPEC tool tree.

--- a/workloads/linux/spec2006/rules.mk
+++ b/workloads/linux/spec2006/rules.mk
@@ -21,8 +21,12 @@ SPEC2006_GNU_TOOLCHAIN_ROOT ?=
 SPEC2006_JEMALLOC_ROOT ?=
 SPEC2006_MULTIHART ?= $(MULTIHART)
 SPEC2006_HARTS ?= $(if $(HARTS),$(HARTS),2)
-SPEC2006_MULTIHART_DEFAULT_DTB := xiangshan-fpga-noAIA-$(SPEC2006_HARTS)hart-mem8g
-SPEC2006_DEFAULT_DTB ?= $(if $(DEFAULT_DTB),$(DEFAULT_DTB),$(if $(filter 1,$(SPEC2006_MULTIHART)),$(SPEC2006_MULTIHART_DEFAULT_DTB),xiangshan-fpga-noAIA-novec))
+SPEC2006_DEFAULT_DTB ?= $(if $(DEFAULT_DTB),$(DEFAULT_DTB),$(if $(filter 1,$(SPEC2006_MULTIHART)),,xiangshan-fpga-noAIA-novec))
+ifeq ($(filter 1,$(SPEC2006_MULTIHART)),1)
+ifeq ($(strip $(SPEC2006_DEFAULT_DTB)),)
+$(error DEFAULT_DTB or SPEC2006_DEFAULT_DTB must be specified when MULTIHART=1; use the complete DTS basename without .dts.in)
+endif
+endif
 SPEC2006_TUNE ?= base
 SPEC2006_JOBS ?= $(shell nproc)
 SPEC2006_INPUT ?= ref
@@ -31,9 +35,9 @@ SPEC2006_PROGRESS_N ?= 1
 SPEC2006_PROGRESS_PREFIX := [spec2006 $(SPEC2006_PROGRESS_K)/$(SPEC2006_PROGRESS_N)]
 SPEC2006_BUILDROOT_DIR ?= $(if $(BUILDROOT_DIR),$(BUILDROOT_DIR),$(SPEC2006_REPO_ROOT)/build/buildroot)
 SPEC2006_LINUX_IMAGE ?= $(if $(LINUX_IMAGE),$(LINUX_IMAGE),$(SPEC2006_BUILDROOT_DIR)/output/images/Image)
-SPEC2006_GCPT_ELF ?= $(if $(GCPT_ELF),$(GCPT_ELF),$(SPEC2006_REPO_ROOT)/build/$(if $(filter 1,$(MULTIHART)),LibCheckpoint,LibCheckpointAlpha)/build/gcpt)
-SPEC2006_GCPT_BIN ?= $(if $(GCPT_BIN),$(GCPT_BIN),$(SPEC2006_REPO_ROOT)/build/$(if $(filter 1,$(MULTIHART)),LibCheckpoint,LibCheckpointAlpha)/build/gcpt.bin)
-SPEC2006_SBI_BUILD_DIR ?= $(if $(SBI_BUILD_DIR),$(SBI_BUILD_DIR),$(SPEC2006_REPO_ROOT)/build/opensbi)
+SPEC2006_GCPT_ELF ?= $(if $(GCPT_ELF),$(GCPT_ELF),$(SPEC2006_REPO_ROOT)/build/$(if $(filter 1,$(SPEC2006_MULTIHART)),LibCheckpoint,LibCheckpointAlpha)/build/gcpt)
+SPEC2006_GCPT_BIN ?= $(if $(GCPT_BIN),$(GCPT_BIN),$(SPEC2006_REPO_ROOT)/build/$(if $(filter 1,$(SPEC2006_MULTIHART)),LibCheckpoint,LibCheckpointAlpha)/build/gcpt.bin)
+SPEC2006_SBI_BUILD_DIR ?= $(if $(SBI_BUILD_DIR),$(SBI_BUILD_DIR),$(SPEC2006_REPO_ROOT)/build/$(if $(filter 1,$(SPEC2006_MULTIHART)),opensbi-multihart,opensbi))
 SPEC2006_SBI_BIN ?= $(if $(SBI_BIN),$(SBI_BIN),$(SPEC2006_SBI_BUILD_DIR)/build/platform/generic/firmware/fw_jump.bin)
 SPEC2006_BUILDROOT_CROSS_COMPILE ?= $(SPEC2006_BUILDROOT_DIR)/output/host/bin/riscv64-linux-
 SPEC2006_DTC ?= $(SPEC2006_BUILDROOT_DIR)/output/host/bin/dtc
@@ -145,6 +149,8 @@ $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin: $$(SPEC2006_DTS_SOURCES) $$(SPEC2006_
 	@CROSS_COMPILE="$$(SPEC2006_BUILDROOT_CROSS_COMPILE)" \
 	DTC="$$(SPEC2006_DTC)" \
 	DEFAULT_DTB="$$(SPEC2006_DEFAULT_DTB)" \
+	MULTIHART="$$(SPEC2006_MULTIHART)" \
+	HARTS="$$(SPEC2006_HARTS)" \
 	SPEC2006_PROGRESS_K="$$(SPEC2006_PROGRESS_K)" \
 	SPEC2006_PROGRESS_N="$$(SPEC2006_PROGRESS_N)" \
 	bash "$$(SPEC2006_SCRIPTS_DIR)/build-firmware-linux.sh" "$$(SPEC2006_GCPT_BIN)" "$$(SPEC2006_SBI_BUILD_DIR)" "$$(SPEC2006_DTS_DIR)" "$$(SPEC2006_LINUX_IMAGE)" "$(SPEC2006_BUILD_DIR)/$(1)"


### PR DESCRIPTION
## Summary

This PR adds end-to-end multi-hart Linux firmware layout support for 2 to 128 harts.

It:

- defines a fixed QEMU checkpoint memory layout shared by all supported hart counts
- adds validated 2-hart/8 GiB and 32-hart/64 GiB DTS configurations
- requires an explicit matching DTS for multi-hart builds
- validates hart count, checkpoint reservation, component sizes, and DRAM bounds
- prevents stale rootfs and firmware reuse when hart count or DTS selection changes
- propagates multi-hart settings through the generic Linux and SPEC2006 build paths
- embeds the OpenSBI `fw_jump.bin` payload in multi-hart LibCheckpoint GCPT images

## Memory Layout

| Address range | Purpose |
|---|---|
| `0x80000000-0x800fffff` | GCPT loader |
| `0x80100000-0x801fffff` | OpenSBI |
| `0x80200000-0x802fffff` | DTB |
| `0x80300000-0x885fffff` | 131 MiB checkpoint state window (`no-map`) |
| `0x88600000+` | Linux kernel and aligned initramfs |

OpenSBI is configured with:

- `FW_TEXT_START=0x80100000`
- `FW_JUMP_ADDR=0x88600000`
- `FW_JUMP_FDT_ADDR=0x80200000`

## OpenSBI/GCPT Integration

For multi-hart builds, OpenSBI is now built before LibCheckpoint and passed through `--gcpt-payload`.

The firmware packer accepts the resulting GCPT image only when the bytes after the fixed 1 MiB GCPT region exactly match the selected `fw_jump.bin`. It then preserves the existing packed image layout with OpenSBI at the 1 MiB boundary.

Copied LibCheckpoint build output is removed before configuration so changes to the embedded payload cannot reuse stale artifacts.

Single-hart builds continue to use LibCheckpointAlpha without an embedded payload.

## Validation

The following checks passed:

- 2-hart and 32-hart firmware placement checks
- hart count and selected-DTS CPU count validation
- checkpoint reservation validation
- GCPT, OpenSBI, DTB, kernel, initramfs, and DRAM boundary checks
- rootfs and firmware cache invalidation across parameter round trips
- embedded and fallback GCPT payload checks
- Shell and Python syntax checks
- `git diff --check`

A real LibCheckpoint build produced:

```text
GCPT body:       1,048,576 bytes
OpenSBI payload:   267,920 bytes
Combined image:  1,316,496 bytes