### PR TITLE
fix(spec2006): stabilize multi-hart workload packaging

### DIFF
--- a/workloads/linux/spec2006/rules.mk
+++ b/workloads/linux/spec2006/rules.mk
@@ -98,6 +98,7 @@ $(SPEC2006_BUILD_DIR)/$(1)/download/sentinel:
 
 $(SPEC2006_BUILD_DIR)/$(1)/build-vars.$(SPEC2006_BUILD_VARS_HASH).stamp:
 	@mkdir -p "$$(@D)"
+	@rm -f "$$(@D)"/build-vars.*.stamp
 	@printf '%s\n' "input=$(SPEC2006_INPUT)" "tune=$(SPEC2006_TUNE)" "jobs=$(SPEC2006_JOBS)" "cross_compile=$(SPEC2006_CROSS_COMPILE)" "multihart=$(SPEC2006_MULTIHART)" "harts=$(SPEC2006_HARTS)" > "$$@"
 
 $(SPEC2006_BUILD_DIR)/$(1)/cfg.stamp: spec2006-force
@@ -142,6 +143,7 @@ $(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUI
 	SPEC2006_JOBS="$$(SPEC2006_JOBS)" \
 	MULTIHART="$$(SPEC2006_MULTIHART)" \
 	HARTS="$$(SPEC2006_HARTS)" \
+	MULTIHART_PAYLOAD_DIR=spec \
 	bash "$$(SPEC2006_SCRIPTS_DIR)/build-workload-linux.sh" "$$(SPEC2006_WORKLOAD_DIR)" "$(SPEC2006_BUILD_DIR)/$(1)"
 
 $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin: $$(SPEC2006_DTS_SOURCES) $$(SPEC2006_DEFAULT_DTB_STAMP) $$(SPEC2006_GCPT_BIN) $$(SPEC2006_SCRIPTS_DIR)/build-firmware-linux.sh $(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio $$(SPEC2006_LINUX_IMAGE) $$(SPEC2006_SBI_BIN)


### PR DESCRIPTION
## Summary

- Remove obsolete SPEC2006 `build-vars.*.stamp` files before recording a new build configuration.
- Pass `MULTIHART_PAYLOAD_DIR=spec` so the shared multi-hart packager uses the directory produced by SPEC2006.

## Why

Returning to an earlier build-variable hash, such as `HARTS=2 -> 32 -> 2`, could reuse a stale rootfs because the old stamp still existed.

SPEC2006 packages its runtime under `package/spec`, while the shared wrapper otherwise derives `spec2006` from the workload directory name. Multi-hart packaging therefore needs the payload directory to be specified explicitly.

## Testing

- SPEC2006 multi-hart package regression
- Real Make stamp round trip for `HARTS=2 -> 32 -> 2`
- `git diff --check origin/main..HEAD`