### PR TITLE
feat(spec2017): support multi-hart Linux workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ make linux/spec2006 BENCH=astar INPUT=biglakes \
   SPEC2006_ISO=/path/to/cpu2006.iso \
   MULTIHART=1 HARTS=2 \
   DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
+
+make linux/spec2017 BENCH=mcf MODE=rate INPUT=ref \
+  SPEC2017_ISO=/path/to/cpu2017.iso \
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
 ```
 
 `MULTIHART=1` creates per-hart workload directories, uses `/bin/nemu-trap` to

--- a/workloads/linux/spec2017/README.md
+++ b/workloads/linux/spec2017/README.md
@@ -24,6 +24,38 @@ Full case names are also accepted:
 make linux/spec2017 BENCH=mcf_rate_refrate SPEC2017_ISO=/path/to/cpu2017.iso -jN
 ```
 
+## Build a multi-hart workload
+
+Add `MULTIHART=1`, set `HARTS` to the checkpoint hart count, and select the
+matching multi-hart DTS template explicitly:
+
+```sh
+make linux/spec2017 BENCH=mcf MODE=rate INPUT=ref \
+  SPEC2017_ISO=/path/to/cpu2017.iso \
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
+```
+
+The same options apply to split image exports:
+
+```sh
+make spec2017-images BENCH=mcf MODE=rate INPUT=ref \
+  SPEC2017_ISO=/path/to/cpu2017.iso \
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
+```
+
+The package step creates `/spec0` through `/spec<N-1>` and starts one copy on
+each hart through `/spec_common/launch_multihart.sh`. Each hart uses its own
+`SPEC_ROOT`; the task wrappers emit profiling traps 256, 257, and 258, while
+the launcher reports the aggregate exit status.
+
+`DEFAULT_DTB` is required for multi-hart builds and must be the complete DTS
+basename without `.dts.in`. Its CPU count must match `HARTS`. SPEC2017 also
+retains its memory-size checks: rate cases require at least 8 GiB and speed
+cases require at least 24 GiB, so select or generate a matching multi-hart
+template with sufficient memory.
+
 The ISO is extracted and installed through a temporary local staging directory,
 then copied into the writable workspace
 `build/linux-workloads/spec2017/spec-src`. Build output stays under:
@@ -100,7 +132,8 @@ make spec2017-images SPEC2017_ISO=/path/to/cpu2017.iso SPEC2017_IMAGE_MODE=all -
 
 `SPEC2017_IMAGE_MODE=all` exports both rate and speed images.
 
-The generated run script emits NEMU profiling traps by default:
+For single-hart images, the generated run script emits NEMU profiling traps by
+default:
 
 ```text
 echo "CMD: ..."
@@ -116,7 +149,9 @@ Disable the begin profiling traps with:
 PROFILING=0 make spec2017-images SPEC2017_ISO=/path/to/cpu2017.iso -jN
 ```
 
-The final `nemu-trap <status>` is always emitted.
+The final `nemu-trap <status>` is always emitted for single-hart images.
+Multi-hart images use the per-hart task wrappers and aggregate launcher
+described above instead.
 
 The repository provides static `xiangshan-fpga-noAIA-novec` DTS templates for the
 SPEC2017 memory profiles used by default. The embedded DTB is selected per

--- a/workloads/linux/spec2017/build.sh
+++ b/workloads/linux/spec2017/build.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 : "${SPEC2017_ELF_ONLY:=false}"
 : "${SPEC2017_ALL_RUNS:=false}"
 : "${SPEC2017_PROFILING:=1}"
+: "${SPEC2017_MULTIHART:=0}"
 : "${SPEC2017_LOG_DIR:=$WORKLOAD_BUILD_DIR/logs}"
 : "${PKG_DIR:=$WORKLOAD_BUILD_DIR/package}"
 
@@ -43,4 +44,5 @@ python3 "$WORKLOAD_DIR/spec2017-package.py" \
   --tune "$SPEC2017_TUNE" \
   --jobs "$SPEC2017_JOBS" \
   --profiling "$SPEC2017_PROFILING" \
+  --multihart "$SPEC2017_MULTIHART" \
   "${python_args[@]}"

--- a/workloads/linux/spec2017/rules.mk
+++ b/workloads/linux/spec2017/rules.mk
@@ -19,8 +19,15 @@ SPEC2017_PREPARE_SCRIPT := $(SPEC2017_WORKLOAD_DIR)/prepare-spec-workspace.sh
 SPEC2017_CROSS_COMPILE ?= riscv64-unknown-linux-gnu-
 SPEC2017_COMPILER_ROOT ?=
 SPEC2017_GNU_TOOLCHAIN_ROOT ?=
+SPEC2017_MULTIHART ?= $(MULTIHART)
+SPEC2017_HARTS ?= $(if $(HARTS),$(HARTS),2)
 SPEC2017_EXPLICIT_DEFAULT_DTB := $(if $(DEFAULT_DTB),1,$(if $(filter undefined,$(origin SPEC2017_DEFAULT_DTB)),,1))
-SPEC2017_DEFAULT_DTB ?= $(if $(DEFAULT_DTB),$(DEFAULT_DTB),xiangshan-fpga-noAIA-novec)
+SPEC2017_DEFAULT_DTB ?= $(if $(DEFAULT_DTB),$(DEFAULT_DTB),$(if $(filter 1,$(SPEC2017_MULTIHART)),,xiangshan-fpga-noAIA-novec))
+ifeq ($(filter 1,$(SPEC2017_MULTIHART)),1)
+ifeq ($(strip $(SPEC2017_DEFAULT_DTB)),)
+$(error DEFAULT_DTB or SPEC2017_DEFAULT_DTB must be specified when MULTIHART=1; use the complete DTS basename without .dts.in)
+endif
+endif
 SPEC2017_RATE_DTB_MEMORY ?= 8g
 SPEC2017_SPEED_DTB_MEMORY ?= 24g
 SPEC2017_DTB_MEMORY ?=
@@ -38,9 +45,9 @@ SPEC2017_PROGRESS_N ?= 1
 SPEC2017_PROGRESS_PREFIX := [spec2017 $(SPEC2017_PROGRESS_K)/$(SPEC2017_PROGRESS_N)]
 SPEC2017_BUILDROOT_DIR ?= $(if $(BUILDROOT_DIR),$(BUILDROOT_DIR),$(SPEC2017_REPO_ROOT)/build/buildroot)
 SPEC2017_LINUX_IMAGE ?= $(if $(LINUX_IMAGE),$(LINUX_IMAGE),$(SPEC2017_BUILDROOT_DIR)/output/images/Image)
-SPEC2017_GCPT_ELF ?= $(if $(GCPT_ELF),$(GCPT_ELF),$(SPEC2017_REPO_ROOT)/build/LibCheckpointAlpha/build/gcpt)
-SPEC2017_GCPT_BIN ?= $(if $(GCPT_BIN),$(GCPT_BIN),$(SPEC2017_REPO_ROOT)/build/LibCheckpointAlpha/build/gcpt.bin)
-SPEC2017_SBI_BUILD_DIR ?= $(if $(SBI_BUILD_DIR),$(SBI_BUILD_DIR),$(SPEC2017_REPO_ROOT)/build/opensbi)
+SPEC2017_GCPT_ELF ?= $(if $(GCPT_ELF),$(GCPT_ELF),$(SPEC2017_REPO_ROOT)/build/$(if $(filter 1,$(SPEC2017_MULTIHART)),LibCheckpoint,LibCheckpointAlpha)/build/gcpt)
+SPEC2017_GCPT_BIN ?= $(if $(GCPT_BIN),$(GCPT_BIN),$(SPEC2017_REPO_ROOT)/build/$(if $(filter 1,$(SPEC2017_MULTIHART)),LibCheckpoint,LibCheckpointAlpha)/build/gcpt.bin)
+SPEC2017_SBI_BUILD_DIR ?= $(if $(SBI_BUILD_DIR),$(SBI_BUILD_DIR),$(SPEC2017_REPO_ROOT)/build/$(if $(filter 1,$(SPEC2017_MULTIHART)),opensbi-multihart,opensbi))
 SPEC2017_SBI_BIN ?= $(if $(SBI_BIN),$(SBI_BIN),$(SPEC2017_SBI_BUILD_DIR)/build/platform/generic/firmware/fw_jump.bin)
 SPEC2017_BUILDROOT_CROSS_COMPILE ?= $(SPEC2017_BUILDROOT_DIR)/output/host/bin/riscv64-linux-
 SPEC2017_DTC ?= $(SPEC2017_BUILDROOT_DIR)/output/host/bin/dtc
@@ -52,7 +59,7 @@ spec2017_case_dtb_min_memory_bytes = $(if $(findstring _speed_,$(1)),$(SPEC2017_
 spec2017_case_cfg = $(if $(SPEC2017_EXPLICIT_CFG),$(SPEC2017_CFG),$(if $(findstring _speed_,$(1)),$(SPEC2017_SPEED_CFG),$(SPEC2017_RATE_CFG)))
 spec2017_case_cfg_hash = $(shell if [ -f "$(abspath $(call spec2017_case_cfg,$(1)))" ]; then sha256sum "$(abspath $(call spec2017_case_cfg,$(1)))" | cut -d ' ' -f 1; else printf 'missing'; fi)
 SPEC2017_PYTHON := PYTHONDONTWRITEBYTECODE=1 python3
-SPEC2017_BUILD_VARS_HASH := $(shell printf '%s\n' '$(SPEC2017_PROFILING)' '$(SPEC2017_TUNE)' '$(SPEC2017_CROSS_COMPILE)' '$(SPEC2017_COMPILER_ROOT)' '$(SPEC2017_GNU_TOOLCHAIN_ROOT)' | sha256sum | cut -d ' ' -f 1)
+SPEC2017_BUILD_VARS_HASH := $(shell printf '%s\n' '$(SPEC2017_PROFILING)' '$(SPEC2017_TUNE)' '$(SPEC2017_CROSS_COMPILE)' '$(SPEC2017_COMPILER_ROOT)' '$(SPEC2017_GNU_TOOLCHAIN_ROOT)' 'multihart=$(SPEC2017_MULTIHART)' 'harts=$(SPEC2017_HARTS)' | sha256sum | cut -d ' ' -f 1)
 SPEC2017_CASE := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --resolve-case --bench '$(BENCH)' --input-set '$(SPEC2017_INPUT)' --mode '$(SPEC2017_MODE)' 2>/dev/null)
 SPEC2017_ALL_CASES := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --list-cases --input-set all --mode all 2>/dev/null)
 SPEC2017_SELECTED_CASES := $(shell $(SPEC2017_PYTHON) $(SPEC2017_HELPER) --list-cases --input-set $(SPEC2017_INPUT) --mode $(SPEC2017_MODE) 2>/dev/null)
@@ -125,7 +132,8 @@ $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp: | spec
 
 $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp:
 	@mkdir -p "$$(@D)"
-	@printf '%s\n' "profiling=$(SPEC2017_PROFILING)" > "$$@"
+	@rm -f "$$(@D)"/build-vars.*.stamp
+	@printf '%s\n' "profiling=$(SPEC2017_PROFILING)" "multihart=$(SPEC2017_MULTIHART)" "harts=$(SPEC2017_HARTS)" > "$$@"
 
 $(SPEC2017_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh
 	@mkdir -p "$$(dir $$@)"
@@ -146,7 +154,7 @@ $(SPEC2017_BUILD_DIR)/$(1)/elf/$(1).elf: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BU
 	SPEC2017_PROFILING="$$(SPEC2017_PROFILING)" \
 	bash "$$(abspath $$(SPEC2017_WORKLOAD_DIR))/build.sh"
 
-$(SPEC2017_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh $(SPEC2017_BUILD_DIR)/$(1)/download/sentinel $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp $$(SPEC2017_SCRIPTS_DIR)/build-workload-linux.sh
+$(SPEC2017_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh $(SPEC2017_BUILD_DIR)/$(1)/download/sentinel $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp $$(SPEC2017_SCRIPTS_DIR)/build-workload-linux.sh $$(SPEC2017_SCRIPTS_DIR)/package-multihart-rootfs.py
 	@CROSS_COMPILE="$$(SPEC2017_CROSS_COMPILE)" \
 	SPEC2017_PROGRESS_K="$$(SPEC2017_PROGRESS_K)" \
 	SPEC2017_PROGRESS_N="$$(SPEC2017_PROGRESS_N)" \
@@ -158,6 +166,10 @@ $(SPEC2017_BUILD_DIR)/$(1)/rootfs.cpio: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUI
 	SPEC2017_TUNE="$$(SPEC2017_TUNE)" \
 	SPEC2017_JOBS="$$(SPEC2017_JOBS)" \
 	SPEC2017_PROFILING="$$(SPEC2017_PROFILING)" \
+	SPEC2017_MULTIHART="$$(SPEC2017_MULTIHART)" \
+	MULTIHART="$$(SPEC2017_MULTIHART)" \
+	HARTS="$$(SPEC2017_HARTS)" \
+	MULTIHART_PAYLOAD_DIR=spec \
 	bash "$$(SPEC2017_SCRIPTS_DIR)/build-workload-linux.sh" "$$(SPEC2017_WORKLOAD_DIR)" "$(SPEC2017_BUILD_DIR)/$(1)"
 
 $(SPEC2017_BUILD_DIR)/$(1)/firmware/dtb-$(call spec2017_case_dtb_tag,$(1)).stamp: spec2017-force
@@ -176,6 +188,8 @@ $(SPEC2017_BUILD_DIR)/$(1)/fw_payload.bin: $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_
 	DEFAULT_DTB="$$(SPEC2017_DEFAULT_DTB)" \
 	DTB_MEMORY_PROFILE="$(call spec2017_case_dtb_profile,$(1))" \
 	DTB_MIN_MEMORY_BYTES="$(call spec2017_case_dtb_min_memory_bytes,$(1))" \
+	MULTIHART="$$(SPEC2017_MULTIHART)" \
+	HARTS="$$(SPEC2017_HARTS)" \
 	SPEC2017_PROGRESS_K="$$(SPEC2017_PROGRESS_K)" \
 	SPEC2017_PROGRESS_N="$$(SPEC2017_PROGRESS_N)" \
 	bash "$$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh" "$$(SPEC2017_GCPT_BIN)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$(SPEC2017_DTS_DIR)" "$$(SPEC2017_LINUX_IMAGE)" "$(SPEC2017_BUILD_DIR)/$(1)"
@@ -184,7 +198,7 @@ linux/$(1): $(SPEC2017_BUILD_DIR)/$(1)/fw_payload.bin
 
 WORKLOAD_PHONY_TARGETS += linux/$(1)
 
-$(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh $(SPEC2017_BUILD_DIR)/$(1)/download/sentinel $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_GCPT_BIN) $$(SPEC2017_GCPT_ELF) $$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh $$(SPEC2017_LINUX_IMAGE) $$(SPEC2017_SBI_BIN) | spec2017-check-spec-config
+$(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh $(SPEC2017_BUILD_DIR)/$(1)/download/sentinel $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_GCPT_BIN) $$(SPEC2017_GCPT_ELF) $$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh $$(SPEC2017_SCRIPTS_DIR)/package-multihart-rootfs.py $$(SPEC2017_LINUX_IMAGE) $$(SPEC2017_SBI_BIN) | spec2017-check-spec-config
 	@printf '$(SPEC2017_PROGRESS_PREFIX) Packaging split run images for $(1)\n'
 	@WORKLOAD_DIR="$$(abspath $$(SPEC2017_WORKLOAD_DIR))" \
 	WORKLOAD_BUILD_DIR="$$(abspath $(SPEC2017_BUILD_DIR)/$(1))" \
@@ -201,6 +215,7 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 	SPEC2017_JOBS="$$(SPEC2017_JOBS)" \
 	SPEC2017_ALL_RUNS=1 \
 	SPEC2017_PROFILING="$$(SPEC2017_PROFILING)" \
+	SPEC2017_MULTIHART="$$(SPEC2017_MULTIHART)" \
 	bash "$$(abspath $$(SPEC2017_WORKLOAD_DIR))/build.sh"
 	@printf '$(SPEC2017_PROGRESS_PREFIX) Exporting $(1) split artifacts to $(SPEC2017_IMAGE_DIR)\n'
 	@mkdir -p "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs/build_elf" "$(SPEC2017_IMAGE_DIR)/stamps"
@@ -217,16 +232,25 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 	@$(SPEC2017_PYTHON) "$(SPEC2017_HELPER)" --list-packaged-variants --out-dir "$(SPEC2017_BUILD_DIR)/$(1)" | while IFS="	" read -r variant build_dir; do \
 		printf '$(SPEC2017_PROGRESS_PREFIX) Assembling firmware for %s\n' "$$$$variant"; \
 		rm -f "$$$$build_dir/rootfs.cpio"; \
+		if [ "$$(SPEC2017_MULTIHART)" = 1 ]; then \
+			$$(SPEC2017_PYTHON) "$$(SPEC2017_SCRIPTS_DIR)/package-multihart-rootfs.py" --pkg-dir "$$$$build_dir/package" --harts "$$(SPEC2017_HARTS)" --workload-name spec; \
+		fi; \
 		(cd "$$$$build_dir/package" && find . | fakeroot cpio -o -H newc > "$$$$build_dir/rootfs.cpio" 2>/dev/null); \
 		CROSS_COMPILE="$$(SPEC2017_BUILDROOT_CROSS_COMPILE)" \
 		DTC="$$(SPEC2017_DTC)" \
 		DEFAULT_DTB="$$(SPEC2017_DEFAULT_DTB)" \
 		DTB_MEMORY_PROFILE="$(call spec2017_case_dtb_profile,$(1))" \
 		DTB_MIN_MEMORY_BYTES="$(call spec2017_case_dtb_min_memory_bytes,$(1))" \
+		MULTIHART="$$(SPEC2017_MULTIHART)" \
+		HARTS="$$(SPEC2017_HARTS)" \
 		SPEC2017_PROGRESS_K="$$(SPEC2017_PROGRESS_K)" \
 		SPEC2017_PROGRESS_N="$$(SPEC2017_PROGRESS_N)" \
 		bash "$$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh" "$$(SPEC2017_GCPT_BIN)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$(SPEC2017_DTS_DIR)" "$$(SPEC2017_LINUX_IMAGE)" "$$$$build_dir"; \
-		cp "$$$$build_dir/package/spec/run.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
+		if [ -f "$$$$build_dir/package/spec/run.sh" ]; then \
+			cp "$$$$build_dir/package/spec/run.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
+		else \
+			cp "$$$$build_dir/package/spec_common/launch_multihart.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
+		fi; \
 		cp "$$(SPEC2017_LINUX_IMAGE)" "$(SPEC2017_IMAGE_DIR)/kernel/$$$$variant.Image"; \
 		cp "$$$$build_dir/rootfs.cpio" "$(SPEC2017_IMAGE_DIR)/rootfs/$$$$variant.rootfs.cpio"; \
 		cp "$$$$build_dir/fw_payload.bin" "$(SPEC2017_IMAGE_DIR)/bin/$$$$variant.fw_payload.bin"; \

--- a/workloads/linux/spec2017/spec2017-package.py
+++ b/workloads/linux/spec2017/spec2017-package.py
@@ -849,7 +849,7 @@ def shell_from_specinvoke(spec_dir, run_dir, log_dir):
     for line in output:
         line = line.replace(run_dir_ref, "./")
         line = line.replace(str(run_dir) + "/", "./")
-        line = line.replace(str(run_dir), "/spec")
+        line = line.replace(str(run_dir), "${SPEC_ROOT:-/spec}")
         commands.append(line)
     if not commands:
         raise RuntimeError(f"specinvoke produced no runnable shell commands from {cmd_file}")
@@ -911,7 +911,7 @@ def write_variants_metadata(out_dir, variants):
     write_json(out_dir / "variants.json", serializable)
 
 
-def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling):
+def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling, multihart="0"):
     spec_root = pkg_dir / "spec"
     run_sh = spec_root / "run.sh"
     script_lines = [
@@ -920,7 +920,9 @@ def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling):
         "mkdir -p /proc /sys /tmp",
         "mount -t proc proc /proc 2>/dev/null || true",
         "mount -t sysfs sysfs /sys 2>/dev/null || true",
-        "cd /spec",
+        'SPEC_ROOT="${SPEC_ROOT:-/spec}"',
+        "export SPEC_ROOT",
+        'cd "$SPEC_ROOT"',
         "export LC_ALL=C",
         "export OMP_NUM_THREADS=1",
         "export OMP_THREAD_LIMIT=1",
@@ -936,7 +938,7 @@ def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling):
             f"  spec_cmd={shlex.quote(command)}",
             "  echo \"CMD: $spec_cmd\"",
         ]
-        if profiling == "1":
+        if profiling == "1" and multihart != "1":
             command_lines.extend(["  nemu-trap 256", "  nemu-trap 257"])
         command_lines.extend(
             [
@@ -944,7 +946,8 @@ def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling):
                 "  status=$?",
             ]
         )
-        command_lines.append("  nemu-trap \"$status\"")
+        if multihart != "1":
+            command_lines.append("  nemu-trap \"$status\"")
         command_lines.append("fi")
         script_lines.extend(
             command_lines
@@ -973,7 +976,7 @@ def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling):
     (etc / "inittab").write_text("::once:/bin/sh /spec/run.sh\n", encoding="utf-8")
 
 
-def package_runtime_variant(variant, run_dir, profiling):
+def package_runtime_variant(variant, run_dir, profiling, multihart):
     build_dir = variant["build_dir"]
     pkg_dir = build_dir / "package"
     if pkg_dir.exists():
@@ -981,7 +984,7 @@ def package_runtime_variant(variant, run_dir, profiling):
     (pkg_dir / "spec").mkdir(parents=True)
     status(f"Packaging rootfs for {variant['name']}")
     copy_tree_contents(run_dir, pkg_dir / "spec")
-    write_runtime_files(pkg_dir, variant["name"], variant["commands"], profiling)
+    write_runtime_files(pkg_dir, variant["name"], variant["commands"], profiling, multihart)
 
 
 def package_case(args):
@@ -1038,7 +1041,7 @@ def package_case(args):
             shutil.rmtree(variant_root)
         for variant in variants:
             variant["build_dir"] = variant_root / variant["name"]
-            package_runtime_variant(variant, run_dir, args.profiling)
+            package_runtime_variant(variant, run_dir, args.profiling, args.multihart)
         write_variants_metadata(out_dir, variants)
         return
     if pkg_dir is None:
@@ -1048,7 +1051,7 @@ def package_case(args):
     (pkg_dir / "spec").mkdir(parents=True)
     status(f"Packaging rootfs for {args.case}")
     copy_tree_contents(run_dir, pkg_dir / "spec")
-    write_runtime_files(pkg_dir, args.case, run_commands, args.profiling)
+    write_runtime_files(pkg_dir, args.case, run_commands, args.profiling, args.multihart)
 
 
 def prepare_only(args):
@@ -1092,6 +1095,7 @@ def main():
     parser.add_argument("--elf-only", action="store_true")
     parser.add_argument("--all-runs", action="store_true")
     parser.add_argument("--profiling", choices=("0", "1"), default="1")
+    parser.add_argument("--multihart", choices=("0", "1"), default="0")
     args = parser.parse_args()
     if args.list_cases:
         print(" ".join(filter_cases(all_cases(), args.input_set, args.mode).keys()))


### PR DESCRIPTION
## Summary

- add SPEC2017 multi-hart controls and require an explicit matching DTB
- include multi-hart mode and hart count in build cache identity and firmware assembly
- package per-hart SPEC roots for normal and split-image workflows
- keep profiling trap ownership with the shared per-hart wrappers and aggregate launcher
- document multi-hart usage and SPEC2017 memory requirements
