### PR TITLE
feat(dts): add xiangshan-fpga-AIA-mem16g.dts

### DIFF
--- a/dts/xiangshan-fpga-AIA-mem16G.dts.in
+++ b/dts/xiangshan-fpga-AIA-mem16G.dts.in
@@ -1,0 +1,207 @@
+/*
+ * XiangShan FPGA DTS used by the fpga board flow.
+ *
+ * 1. AIA uses the Kunminghu-v2 APLIC and IMSIC address map.
+ * 2. APLIC exposes 64 interrupt sources.
+ * 3. The FPGA DDR window exposes 16 GiB from 0x80000000.
+ * 4. UART16550 is exposed as the serial console.
+ */
+
+/dts-v1/;
+
+/ {
+	compatible = "freechips,rocketchip-unknown-dev";
+	model = "xiangshan,Kunminghu-dev";
+	#address-cells = <2>;
+	#size-cells = <2>;
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+
+		cpu0: cpu@0 {
+			compatible = "ICT,xiangshan", "riscv";
+			device_type = "cpu";
+			reg = <0x0>;
+			status = "okay";
+
+			d-cache-block-size = <64>;
+			d-cache-sets = <256>;
+			d-cache-size = <65536>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <48>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <256>;
+			i-cache-size = <65536>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <48>;
+			mmu-type = "riscv,sv48";
+			clock-frequency = <0>;
+			timebase-frequency = <1000000>;
+			tlb-split;
+
+			/* Match the Kunminghu-v2 Linux CPU capability description. */
+			riscv,isa = "rv64imafdcvh_smaia_smstateen_sscofpmf_sstc_zicntr_zihpm_zicboz_zicbom_svpbmt_sdtrig_smcsrind_sscsrind_svade";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions =
+				"i", "m", "a", "f", "d", "c", "v", "h",
+				"sdtrig", "sha", "shcounterenw", "shgatpa",
+				"shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+				"shvstvecd", "smaia", "smcsrind", "smdbltrp",
+				"smmpm", "smnpm", "smrnmi", "smstateen",
+				"ss1p13", "ssaia", "ssccptr", "sscofpmf",
+				"sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+				"sspm", "ssstateen", "ssstrict", "sstc",
+				"sstvala", "sstvecd", "ssu64xl", "supm",
+				"sv39", "sv48", "svade", "svbare", "svinval",
+				"svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+				"zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+				"zbs", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+				"zic64b", "zicbom", "zicbop", "zicboz",
+				"ziccamoa", "ziccif", "zicclsm", "ziccrse",
+				"zicntr", "zicond", "zicsr", "zifencei",
+				"zihintntl", "zihintpause", "zihpm", "zimop",
+				"zkn", "zknd", "zkne", "zknh", "zksed",
+				"zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+				"zvkt", "zvl128b", "zvl32b", "zvl64b";
+			riscv,cbom-block-size = <0x40>;
+			riscv,cboz-block-size = <0x40>;
+
+			next-level-cache = <&l2_cache>;
+
+			intc_cpu0: interrupt-controller {
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+
+	l2_cache: l2-cache {
+		compatible = "cache";
+		cache-level = <2>;
+		cache-block-size = <64>;
+		cache-size = <1048576>;
+	};
+
+	memory: memory@80000000 {
+		device_type = "memory";
+		/* 16 GiB FPGA DDR window starting at 0x80000000. */
+		reg = <0x0 0x80000000 0x4 0x00000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+	};
+
+	soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		compatible = "freechips,rocketchip-unknown-soc", "simple-bus";
+		ranges;
+
+		/* CLINT remains the timer source when AIA is enabled. */
+		clint: clint@38000000 {
+			compatible = "riscv,clint0";
+			reg = <0x0 0x38000000 0x0 0x10000>;
+			reg-names = "control";
+			interrupts-extended = <&intc_cpu0 3 &intc_cpu0 7>;
+		};
+
+		debug-controller@38020000 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			debug-attach = "jtag";
+			reg = <0x0 0x38020000 0x0 0x1000>;
+			reg-names = "control";
+			interrupts-extended = <&intc_cpu0 65535>;
+		};
+
+		imsics_m: imsics@3a800000 {
+			#address-cells = <0>;
+			riscv,num-ids = <0xff>;
+			reg = <0x0 0x3a800000 0x0 0x10000>;
+			msi-controller;
+			interrupt-controller;
+			#interrupt-cells = <0x00>;
+			compatible = "riscv,imsics";
+			interrupts-extended = <&intc_cpu0 11>;
+		};
+
+		imsics_s: imsics@3b000000 {
+			#address-cells = <0>;
+			riscv,num-ids = <0xff>;
+			reg = <0x0 0x3b000000 0x0 0x80000>;
+			msi-controller;
+			interrupt-controller;
+			#interrupt-cells = <0x00>;
+			compatible = "riscv,imsics";
+			riscv,guest-index-bits = <0x03>;
+			interrupts-extended = <&intc_cpu0 9>;
+		};
+
+		aplic_s: aplic@31120000 {
+			#address-cells = <0>;
+			riscv,num-sources = <0x40>;
+			reg = <0x0 0x31120000 0x0 0x8000>;
+			msi-parent = <&imsics_s>;
+			interrupt-controller;
+			#interrupt-cells = <0x02>;
+			compatible = "riscv,aplic";
+		};
+
+		aplic_m: aplic@31100000 {
+			#address-cells = <0>;
+			riscv,delegate = <&aplic_s 0x01 0x40>;
+			riscv,children = <&aplic_s>;
+			riscv,num-sources = <0x40>;
+			reg = <0x0 0x31100000 0x0 0x8000>;
+			msi-parent = <&imsics_m>;
+			interrupt-controller;
+			#interrupt-cells = <0x02>;
+			compatible = "riscv,aplic";
+		};
+
+		/*
+		 * Board-specific FPGA peripheral: the external AXI UART16550 used as
+		 * the Linux console on fpga. Keep the 32-bit MMIO spacing and the
+		 * 50 MHz input clock to match the FPGA wrapper.
+		 */
+		uart0: serial@310b0000 {
+			compatible = "ns16550a";
+			reg = <0x0 0x310b0000 0x0 0x10000>;
+			reg-shift = <0x2>;
+			reg-io-width = <0x4>;
+			clock-frequency = <50000000>;
+			current-speed = <115200>;
+			status = "okay";
+		};
+	};
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	chosen {
+		/*
+		 * UART16550 has no Linux interrupt wiring in this FPGA template.
+		 * Use the SBI console after early boot.
+		 */
+		bootargs = "console=hvc0 earlycon=sbi loglevel=8";
+		stdout-path = "serial0:115200n8";
+		linux,initrd-start = <INITRAMFS_BEGIN_HI INITRAMFS_BEGIN_LO>;
+		linux,initrd-end = <INITRAMFS_END_HI INITRAMFS_END_LO>;
+
+		opensbi-config {
+			compatible = "opensbi,config";
+			cold-boot-harts = <&cpu0>;
+		};
+	};
+};


### PR DESCRIPTION
Add a single-hart XiangShan FPGA device-tree profile with 16 GiB DDR and 64 APLIC interrupt sources.

Match riscv-linux devel's kmh-v2.dtsi for the APLIC and IMSIC address windows, IMSIC IDs and guest-file layout, and CPU ISA declarations. Keep the workload-builder FPGA console, initramfs, and OpenSBI settings.

Override the upstream 96-source and 13 GiB declarations for this 64-source, 16 GiB FPGA configuration.