### PR TITLE
fix(spec2026): fix speed mode input generation

### DIFF
--- a/workloads/linux/spec2026/configs/riscv_gcc15_base.cfg
+++ b/workloads/linux/spec2026/configs/riscv_gcc15_base.cfg
@@ -33,6 +33,8 @@ default:
    preenv               = 1
    reportable           = 0
    tune                 = base
+   setup_submit_flac_s  = qemu-riscv64 -L %{gcc_dir}/sysroot ${command}
+   setup_submit_graph500_s = qemu-riscv64 -L %{gcc_dir}/sysroot ${command}
 
 default:
    copies                 = 1


### PR DESCRIPTION
Run `817.flac_s` and `818.graph500_s` setup commands through QEMU during SPEC CPU 2026 packaging
