### PR TITLE
feat(spec): export debug artifacts with workload images

### DIFF
--- a/scripts/export-linux-debug-artifacts.sh
+++ b/scripts/export-linux-debug-artifacts.sh
@@ -7,6 +7,12 @@ WORKLOAD_BUILD_DIR="$(realpath "$3")"
 IMAGE_DIR="$(realpath -m "$4")"
 ARTIFACT_NAME="$5"
 DTB_BASENAME="$6"
+WORKLOAD_ELF="$(realpath "${WORKLOAD_ELF:?WORKLOAD_ELF must be set}")"
+BUILD_LOG="$(realpath "${BUILD_LOG:?BUILD_LOG must be set}")"
+RUN_COMMAND="$(realpath "${RUN_COMMAND:?RUN_COMMAND must be set}")"
+SPEC_CONFIG="$(realpath "${SPEC_CONFIG:?SPEC_CONFIG must be set}")"
+GCPT_ELF="$(realpath "${GCPT_ELF:?GCPT_ELF must be set}")"
+GCPT_BIN="$(realpath "${GCPT_BIN:?GCPT_BIN must be set}")"
 
 mapfile -t vmlinux_files < <(find "$BUILDROOT_DIR/output/build" -path '*/vmlinux' -type f -print | sort)
 if [ "${#vmlinux_files[@]}" -ne 1 ]; then
@@ -24,10 +30,8 @@ SBI_ELF="$SBI_BUILD_DIR/build/platform/generic/firmware/fw_jump.elf"
 SBI_CONFIG="$SBI_BUILD_DIR/platform/generic/configs/defconfig"
 FIRMWARE_IMAGE="$WORKLOAD_BUILD_DIR/fw_payload.bin"
 ROOTFS="$WORKLOAD_BUILD_DIR/rootfs.cpio"
-GCPT_ELF="$IMAGE_DIR/gcpt/gcpt.elf"
-GCPT_BIN="$IMAGE_DIR/gcpt/gcpt.bin"
 
-for file in "$SYSTEM_MAP" "$KERNEL_CONFIG" "$DTB_FILE" "$DTS_FILE" "$SBI_ELF" "$SBI_CONFIG" "$FIRMWARE_IMAGE" "$ROOTFS" "$GCPT_ELF" "$GCPT_BIN"; do
+for file in "$SYSTEM_MAP" "$KERNEL_CONFIG" "$DTB_FILE" "$DTS_FILE" "$SBI_ELF" "$SBI_CONFIG" "$FIRMWARE_IMAGE" "$ROOTFS" "$WORKLOAD_ELF" "$BUILD_LOG" "$RUN_COMMAND" "$SPEC_CONFIG" "$GCPT_ELF" "$GCPT_BIN"; do
     if [ ! -f "$file" ]; then
         echo "Required debug artifact not found: $file" >&2
         exit 1
@@ -38,8 +42,25 @@ KERNEL_DIR="$IMAGE_DIR/kernel"
 DT_DIR="$IMAGE_DIR/dt"
 SBI_DIR="$IMAGE_DIR/opensbi"
 MANIFEST_DIR="$IMAGE_DIR/manifest"
-mkdir -p "$KERNEL_DIR" "$DT_DIR" "$SBI_DIR" "$MANIFEST_DIR"
+BIN_DIR="$IMAGE_DIR/bin"
+ROOTFS_DIR="$IMAGE_DIR/rootfs"
+ELF_DIR="$IMAGE_DIR/elf"
+CMD_DIR="$IMAGE_DIR/cmd"
+CFG_DIR="$IMAGE_DIR/cfg"
+GCPT_DIR="$IMAGE_DIR/gcpt"
+LOG_DIR="$IMAGE_DIR/logs/build_elf"
+STAMP_DIR="$IMAGE_DIR/stamps"
+mkdir -p "$KERNEL_DIR" "$DT_DIR" "$SBI_DIR" "$MANIFEST_DIR" "$BIN_DIR" "$ROOTFS_DIR" "$ELF_DIR" "$CMD_DIR" "$CFG_DIR" "$GCPT_DIR" "$LOG_DIR" "$STAMP_DIR"
 
+WORKLOAD_ELF_NAME="$(basename "$WORKLOAD_ELF" .elf)"
+cp "$FIRMWARE_IMAGE" "$BIN_DIR/$ARTIFACT_NAME.fw_payload.bin"
+cp "$ROOTFS" "$ROOTFS_DIR/$ARTIFACT_NAME.rootfs.cpio"
+cp "$WORKLOAD_ELF" "$ELF_DIR/$WORKLOAD_ELF_NAME.elf"
+cp "$BUILD_LOG" "$LOG_DIR/$WORKLOAD_ELF_NAME.log"
+cp "$RUN_COMMAND" "$CMD_DIR/$ARTIFACT_NAME.run.sh"
+cp "$SPEC_CONFIG" "$CFG_DIR/$(basename "$SPEC_CONFIG")"
+cp "$GCPT_ELF" "$GCPT_DIR/gcpt.elf"
+cp "$GCPT_BIN" "$GCPT_DIR/gcpt.bin"
 cp "$VMLINUX" "$KERNEL_DIR/$ARTIFACT_NAME.vmlinux"
 cp "$SYSTEM_MAP" "$KERNEL_DIR/$ARTIFACT_NAME.System.map"
 cp "$KERNEL_CONFIG" "$KERNEL_DIR/$ARTIFACT_NAME.config"

--- a/scripts/export-linux-debug-artifacts.sh
+++ b/scripts/export-linux-debug-artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILDROOT_DIR="$(realpath "$1")"
+SBI_BUILD_DIR="$(realpath "$2")"
+WORKLOAD_BUILD_DIR="$(realpath "$3")"
+IMAGE_DIR="$(realpath -m "$4")"
+ARTIFACT_NAME="$5"
+DTB_BASENAME="$6"
+
+mapfile -t vmlinux_files < <(find "$BUILDROOT_DIR/output/build" -path '*/vmlinux' -type f -print | sort)
+if [ "${#vmlinux_files[@]}" -ne 1 ]; then
+    echo "Expected exactly one vmlinux under $BUILDROOT_DIR/output/build, found ${#vmlinux_files[@]}" >&2
+    exit 1
+fi
+
+VMLINUX="${vmlinux_files[0]}"
+KERNEL_BUILD_DIR="$(dirname "$VMLINUX")"
+SYSTEM_MAP="$KERNEL_BUILD_DIR/System.map"
+KERNEL_CONFIG="$KERNEL_BUILD_DIR/.config"
+DTB_FILE="$WORKLOAD_BUILD_DIR/dt/$DTB_BASENAME.dtb"
+DTS_FILE="$WORKLOAD_BUILD_DIR/dt/$DTB_BASENAME.dts"
+SBI_ELF="$SBI_BUILD_DIR/build/platform/generic/firmware/fw_jump.elf"
+SBI_CONFIG="$SBI_BUILD_DIR/platform/generic/configs/defconfig"
+FIRMWARE_IMAGE="$WORKLOAD_BUILD_DIR/fw_payload.bin"
+ROOTFS="$WORKLOAD_BUILD_DIR/rootfs.cpio"
+GCPT_ELF="$IMAGE_DIR/gcpt/gcpt.elf"
+GCPT_BIN="$IMAGE_DIR/gcpt/gcpt.bin"
+
+for file in "$SYSTEM_MAP" "$KERNEL_CONFIG" "$DTB_FILE" "$DTS_FILE" "$SBI_ELF" "$SBI_CONFIG" "$FIRMWARE_IMAGE" "$ROOTFS" "$GCPT_ELF" "$GCPT_BIN"; do
+    if [ ! -f "$file" ]; then
+        echo "Required debug artifact not found: $file" >&2
+        exit 1
+    fi
+done
+
+KERNEL_DIR="$IMAGE_DIR/kernel"
+DT_DIR="$IMAGE_DIR/dt"
+SBI_DIR="$IMAGE_DIR/opensbi"
+MANIFEST_DIR="$IMAGE_DIR/manifest"
+mkdir -p "$KERNEL_DIR" "$DT_DIR" "$SBI_DIR" "$MANIFEST_DIR"
+
+cp "$VMLINUX" "$KERNEL_DIR/$ARTIFACT_NAME.vmlinux"
+cp "$SYSTEM_MAP" "$KERNEL_DIR/$ARTIFACT_NAME.System.map"
+cp "$KERNEL_CONFIG" "$KERNEL_DIR/$ARTIFACT_NAME.config"
+cp "$DTB_FILE" "$DT_DIR/$ARTIFACT_NAME.dtb"
+cp "$DTS_FILE" "$DT_DIR/$ARTIFACT_NAME.dts"
+cp "$SBI_ELF" "$SBI_DIR/fw_jump.elf"
+cp "$SBI_CONFIG" "$SBI_DIR/defconfig"
+
+kernel_offset_mb=2
+dtb_address=0x80180000
+opensbi_jump_address=0x80200000
+multihart=false
+if [ "${MULTIHART:-0}" = 1 ]; then
+    kernel_offset_mb=134
+    dtb_address=0x80200000
+    opensbi_jump_address=0x88600000
+    multihart=true
+fi
+
+megabyte=$((1024 * 1024))
+kernel_size=$(stat -c%s "$VMLINUX")
+initramfs_offset_mb=$((kernel_offset_mb + (kernel_size + megabyte - 1) / megabyte))
+kernel_address=$(printf '0x%x' $((0x80000000 + kernel_offset_mb * megabyte)))
+initramfs_address=$(printf '0x%x' $((0x80000000 + initramfs_offset_mb * megabyte)))
+sha256() {
+    sha256sum "$1" | cut -d ' ' -f 1
+}
+
+cat > "$MANIFEST_DIR/$ARTIFACT_NAME.json" <<EOF
+{
+  "case": "$ARTIFACT_NAME",
+  "multihart": $multihart,
+  "device_tree": {
+    "basename": "$DTB_BASENAME",
+    "dtb": "dt/$ARTIFACT_NAME.dtb",
+    "dts": "dt/$ARTIFACT_NAME.dts",
+    "load_address": "$dtb_address",
+    "sha256": "$(sha256 "$DTB_FILE")"
+  },
+  "opensbi": {
+    "elf": "opensbi/fw_jump.elf",
+    "config": "opensbi/defconfig",
+    "load_address": "0x80100000",
+    "jump_address": "$opensbi_jump_address",
+    "sha256": "$(sha256 "$SBI_ELF")"
+  },
+  "gcpt": {
+    "elf": "gcpt/gcpt.elf",
+    "binary": "gcpt/gcpt.bin",
+    "load_address": "0x80000000",
+    "elf_sha256": "$(sha256 "$GCPT_ELF")",
+    "binary_sha256": "$(sha256 "$GCPT_BIN")"
+  },
+  "kernel": {
+    "vmlinux": "kernel/$ARTIFACT_NAME.vmlinux",
+    "system_map": "kernel/$ARTIFACT_NAME.System.map",
+    "config": "kernel/$ARTIFACT_NAME.config",
+    "load_address": "$kernel_address",
+    "sha256": "$(sha256 "$VMLINUX")"
+  },
+  "initramfs": {
+    "file": "rootfs/$ARTIFACT_NAME.rootfs.cpio",
+    "load_address": "$initramfs_address",
+    "sha256": "$(sha256 "$ROOTFS")"
+  },
+  "firmware": {
+    "file": "bin/$ARTIFACT_NAME.fw_payload.bin",
+    "sha256": "$(sha256 "$FIRMWARE_IMAGE")"
+  }
+}
+EOF

--- a/workloads/linux/spec2006/README.md
+++ b/workloads/linux/spec2006/README.md
@@ -104,18 +104,29 @@ The export directory is organized as:
 ```text
 build/images/spec2006/
   bin/<case>.fw_payload.bin
-  kernel/<case>.Image
+  kernel/<case>.vmlinux
+  kernel/<case>.System.map
+  kernel/<case>.config
   rootfs/<case>.rootfs.cpio
+  dt/<case>.dtb
+  dt/<case>.dts
   elf/<case>.elf
   cmd/<case>.run.sh
   gcpt/gcpt.elf
   gcpt/gcpt.bin
+  opensbi/fw_jump.elf
+  opensbi/defconfig
+  manifest/<case>.json
   cfg/<spec-cfg-name>
   logs/build_elf/<case>.log
   stamps/<case>.images.stamp
 ```
 
-`gcpt/` and `cfg/` are copied once per export tree, not once per case.
+`bin/` is the directly loadable firmware image and `rootfs/` is its initramfs.
+`kernel/` contains the ELF kernel plus its symbol map and configuration for
+debugging; `dt/` contains the exact DTB and generated DTS used by that case.
+`manifest/` records component hashes and load addresses. `gcpt/`, `cfg/`, and
+`opensbi/` are shared by the export tree.
 
 Re-running `make spec2006-images` rebuilds the export tree so the directory
 layout and contents stay complete and consistent.

--- a/workloads/linux/spec2006/rules.mk
+++ b/workloads/linux/spec2006/rules.mk
@@ -163,26 +163,16 @@ WORKLOAD_PHONY_TARGETS += linux/$(1)
 
 $(call spec2006_case_image_stamp,$(1)): $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2006_GCPT_ELF) $(SPEC2006_GCPT_BIN) $(SPEC2006_LINUX_IMAGE) $(SPEC2006_SBI_BIN) $$(SPEC2006_SCRIPTS_DIR)/export-linux-debug-artifacts.sh | spec2006-check-spec-iso
 	@printf '$(SPEC2006_PROGRESS_PREFIX) Exporting $(1) artifacts to $(SPEC2006_IMAGE_DIR)\n'
-	@mkdir -p "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/dt" "$(SPEC2006_IMAGE_DIR)/manifest" "$(SPEC2006_IMAGE_DIR)/logs/build_elf" "$(SPEC2006_IMAGE_DIR)/stamps"
-	@if [ ! -f "$(SPEC2006_IMAGE_DIR)/cfg/$(notdir $(SPEC2006_CFG))" ]; then \
-		printf '$(SPEC2006_PROGRESS_PREFIX) Exporting spec2006 cfg to $(SPEC2006_IMAGE_DIR)/cfg\n'; \
-		cp "$(SPEC2006_CFG)" "$(SPEC2006_IMAGE_DIR)/cfg/$(notdir $(SPEC2006_CFG))"; \
-	fi
-	@if [ ! -f "$(SPEC2006_IMAGE_DIR)/gcpt/gcpt.elf" ] || [ ! -f "$(SPEC2006_IMAGE_DIR)/gcpt/gcpt.bin" ]; then \
-		printf '$(SPEC2006_PROGRESS_PREFIX) Exporting gcpt artifacts to $(SPEC2006_IMAGE_DIR)/gcpt\n'; \
-		cp "$(SPEC2006_GCPT_ELF)" "$(SPEC2006_IMAGE_DIR)/gcpt/gcpt.elf"; \
-		cp "$(SPEC2006_GCPT_BIN)" "$(SPEC2006_IMAGE_DIR)/gcpt/gcpt.bin"; \
-	fi
-	@cp "$(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf" "$(SPEC2006_IMAGE_DIR)/elf/$(1).elf"
-	@cp "$(SPEC2006_BUILD_DIR)/$(1)/logs/build_elf/build.log" "$(SPEC2006_IMAGE_DIR)/logs/build_elf/$(1).log"
-	@MULTIHART="$(SPEC2006_MULTIHART)" bash "$(SPEC2006_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$(SPEC2006_BUILDROOT_DIR)" "$(SPEC2006_SBI_BUILD_DIR)" "$(SPEC2006_BUILD_DIR)/$(1)" "$(SPEC2006_IMAGE_DIR)" "$(1)" "$(SPEC2006_DEFAULT_DTB)"
-	@cp "$(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio" "$(SPEC2006_IMAGE_DIR)/rootfs/$(1).rootfs.cpio"
-	@cp "$(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin" "$(SPEC2006_IMAGE_DIR)/bin/$(1).fw_payload.bin"
-	@if [ -f "$(SPEC2006_BUILD_DIR)/$(1)/package/spec/run.sh" ]; then \
-		cp "$(SPEC2006_BUILD_DIR)/$(1)/package/spec/run.sh" "$(SPEC2006_IMAGE_DIR)/cmd/$(1).run.sh"; \
-	else \
-		cp "$(SPEC2006_BUILD_DIR)/$(1)/package/spec_common/launch_multihart.sh" "$(SPEC2006_IMAGE_DIR)/cmd/$(1).run.sh"; \
-	fi
+	@run_command="$(SPEC2006_BUILD_DIR)/$(1)/package/spec/run.sh"; \
+	if [ ! -f "$$$$run_command" ]; then run_command="$(SPEC2006_BUILD_DIR)/$(1)/package/spec_common/launch_multihart.sh"; fi; \
+	MULTIHART="$(SPEC2006_MULTIHART)" \
+	WORKLOAD_ELF="$(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf" \
+	BUILD_LOG="$(SPEC2006_BUILD_DIR)/$(1)/logs/build_elf/build.log" \
+	RUN_COMMAND="$$$$run_command" \
+	SPEC_CONFIG="$(SPEC2006_CFG)" \
+	GCPT_ELF="$(SPEC2006_GCPT_ELF)" \
+	GCPT_BIN="$(SPEC2006_GCPT_BIN)" \
+	bash "$(SPEC2006_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$(SPEC2006_BUILDROOT_DIR)" "$(SPEC2006_SBI_BUILD_DIR)" "$(SPEC2006_BUILD_DIR)/$(1)" "$(SPEC2006_IMAGE_DIR)" "$(1)" "$(SPEC2006_DEFAULT_DTB)"
 	@touch "$$@"
 endef
 

--- a/workloads/linux/spec2006/rules.mk
+++ b/workloads/linux/spec2006/rules.mk
@@ -161,9 +161,9 @@ linux/$(1): $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin
 
 WORKLOAD_PHONY_TARGETS += linux/$(1)
 
-$(call spec2006_case_image_stamp,$(1)): $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2006_GCPT_ELF) $(SPEC2006_GCPT_BIN) $(SPEC2006_LINUX_IMAGE) | spec2006-check-spec-iso
+$(call spec2006_case_image_stamp,$(1)): $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2006_GCPT_ELF) $(SPEC2006_GCPT_BIN) $(SPEC2006_LINUX_IMAGE) $(SPEC2006_SBI_BIN) $$(SPEC2006_SCRIPTS_DIR)/export-linux-debug-artifacts.sh | spec2006-check-spec-iso
 	@printf '$(SPEC2006_PROGRESS_PREFIX) Exporting $(1) artifacts to $(SPEC2006_IMAGE_DIR)\n'
-	@mkdir -p "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/logs/build_elf" "$(SPEC2006_IMAGE_DIR)/stamps"
+	@mkdir -p "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/dt" "$(SPEC2006_IMAGE_DIR)/manifest" "$(SPEC2006_IMAGE_DIR)/logs/build_elf" "$(SPEC2006_IMAGE_DIR)/stamps"
 	@if [ ! -f "$(SPEC2006_IMAGE_DIR)/cfg/$(notdir $(SPEC2006_CFG))" ]; then \
 		printf '$(SPEC2006_PROGRESS_PREFIX) Exporting spec2006 cfg to $(SPEC2006_IMAGE_DIR)/cfg\n'; \
 		cp "$(SPEC2006_CFG)" "$(SPEC2006_IMAGE_DIR)/cfg/$(notdir $(SPEC2006_CFG))"; \
@@ -175,7 +175,7 @@ $(call spec2006_case_image_stamp,$(1)): $(SPEC2006_PREPARE_STAMP) $(SPEC2006_BUI
 	fi
 	@cp "$(SPEC2006_BUILD_DIR)/$(1)/elf/$(1).elf" "$(SPEC2006_IMAGE_DIR)/elf/$(1).elf"
 	@cp "$(SPEC2006_BUILD_DIR)/$(1)/logs/build_elf/build.log" "$(SPEC2006_IMAGE_DIR)/logs/build_elf/$(1).log"
-	@cp "$(SPEC2006_LINUX_IMAGE)" "$(SPEC2006_IMAGE_DIR)/kernel/$(1).Image"
+	@MULTIHART="$(SPEC2006_MULTIHART)" bash "$(SPEC2006_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$(SPEC2006_BUILDROOT_DIR)" "$(SPEC2006_SBI_BUILD_DIR)" "$(SPEC2006_BUILD_DIR)/$(1)" "$(SPEC2006_IMAGE_DIR)" "$(1)" "$(SPEC2006_DEFAULT_DTB)"
 	@cp "$(SPEC2006_BUILD_DIR)/$(1)/rootfs.cpio" "$(SPEC2006_IMAGE_DIR)/rootfs/$(1).rootfs.cpio"
 	@cp "$(SPEC2006_BUILD_DIR)/$(1)/fw_payload.bin" "$(SPEC2006_IMAGE_DIR)/bin/$(1).fw_payload.bin"
 	@if [ -f "$(SPEC2006_BUILD_DIR)/$(1)/package/spec/run.sh" ]; then \
@@ -222,7 +222,7 @@ spec2006-images: spec2006-check-spec-iso
 		echo "No SPEC2006 cases selected by SPEC2006_INPUT=$(SPEC2006_INPUT)"; \
 		exit 1; \
 	fi; \
-	rm -rf "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/logs" "$(SPEC2006_IMAGE_DIR)/stamps"; \
+	rm -rf "$(SPEC2006_IMAGE_DIR)/bin" "$(SPEC2006_IMAGE_DIR)/kernel" "$(SPEC2006_IMAGE_DIR)/rootfs" "$(SPEC2006_IMAGE_DIR)/elf" "$(SPEC2006_IMAGE_DIR)/cmd" "$(SPEC2006_IMAGE_DIR)/cfg" "$(SPEC2006_IMAGE_DIR)/gcpt" "$(SPEC2006_IMAGE_DIR)/dt" "$(SPEC2006_IMAGE_DIR)/manifest" "$(SPEC2006_IMAGE_DIR)/logs" "$(SPEC2006_IMAGE_DIR)/stamps"; \
 	total="$(words $(SPEC2006_IMAGE_CASES))"; \
 	i=0; \
 	for case in $(SPEC2006_IMAGE_CASES); do \

--- a/workloads/linux/spec2017/README.md
+++ b/workloads/linux/spec2017/README.md
@@ -99,16 +99,29 @@ The export tree is:
 ```text
 build/images/<mode>/
   bin/<variant>.fw_payload.bin
-  kernel/<variant>.Image
+  kernel/<variant>.vmlinux
+  kernel/<variant>.System.map
+  kernel/<variant>.config
   elf/<case>.elf
   cmd/<variant>.run.sh
   rootfs/<variant>.rootfs.cpio
+  dt/<variant>.dtb
+  dt/<variant>.dts
   gcpt/gcpt.elf
   gcpt/gcpt.bin
+  opensbi/fw_jump.elf
+  opensbi/defconfig
+  manifest/<variant>.json
   cfg/riscv-gcc15.cfg
 ```
 
 `<mode>` is `spec2017rate` for rate and `spec2017speed` for speed.
+
+`bin/` is the directly loadable firmware image and `rootfs/` is its initramfs.
+`kernel/` contains the ELF kernel plus its symbol map and configuration for
+debugging; `dt/` contains the exact DTB and generated DTS used by each variant.
+`manifest/` records component hashes and load addresses. `gcpt/`, `cfg/`, and
+`opensbi/` are shared by the export tree.
 
 When SPEC generates multiple run commands for a case, `spec2017-images` exports
 one firmware image, one rootfs, and one `cmd/<variant>.run.sh` per command,

--- a/workloads/linux/spec2017/rules.mk
+++ b/workloads/linux/spec2017/rules.mk
@@ -198,7 +198,7 @@ linux/$(1): $(SPEC2017_BUILD_DIR)/$(1)/fw_payload.bin
 
 WORKLOAD_PHONY_TARGETS += linux/$(1)
 
-$(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh $(SPEC2017_BUILD_DIR)/$(1)/download/sentinel $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_GCPT_BIN) $$(SPEC2017_GCPT_ELF) $$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh $$(SPEC2017_SCRIPTS_DIR)/package-multihart-rootfs.py $$(SPEC2017_LINUX_IMAGE) $$(SPEC2017_SBI_BIN) | spec2017-check-spec-config
+$(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC2017_BUILD_DIR)/$(1)/cfg.$(call spec2017_case_cfg_hash,$(1)).stamp $$(SPEC2017_HELPER) $$(SPEC2017_WORKLOAD_DIR)/build.sh $(SPEC2017_BUILD_DIR)/$(1)/download/sentinel $(SPEC2017_BUILD_DIR)/$(1)/build-vars.$(SPEC2017_BUILD_VARS_HASH).stamp $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_GCPT_BIN) $$(SPEC2017_GCPT_ELF) $$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh $$(SPEC2017_SCRIPTS_DIR)/export-linux-debug-artifacts.sh $$(SPEC2017_SCRIPTS_DIR)/package-multihart-rootfs.py $$(SPEC2017_LINUX_IMAGE) $$(SPEC2017_SBI_BIN) | spec2017-check-spec-config
 	@printf '$(SPEC2017_PROGRESS_PREFIX) Packaging split run images for $(1)\n'
 	@WORKLOAD_DIR="$$(abspath $$(SPEC2017_WORKLOAD_DIR))" \
 	WORKLOAD_BUILD_DIR="$$(abspath $(SPEC2017_BUILD_DIR)/$(1))" \
@@ -218,7 +218,7 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 	SPEC2017_MULTIHART="$$(SPEC2017_MULTIHART)" \
 	bash "$$(abspath $$(SPEC2017_WORKLOAD_DIR))/build.sh"
 	@printf '$(SPEC2017_PROGRESS_PREFIX) Exporting $(1) split artifacts to $(SPEC2017_IMAGE_DIR)\n'
-	@mkdir -p "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs/build_elf" "$(SPEC2017_IMAGE_DIR)/stamps"
+	@mkdir -p "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/dt" "$(SPEC2017_IMAGE_DIR)/manifest" "$(SPEC2017_IMAGE_DIR)/logs/build_elf" "$(SPEC2017_IMAGE_DIR)/stamps"
 	@if [ ! -f "$(SPEC2017_IMAGE_DIR)/cfg/$(notdir $(call spec2017_case_cfg,$(1)))" ]; then \
 		cp "$(abspath $(call spec2017_case_cfg,$(1)))" "$(SPEC2017_IMAGE_DIR)/cfg/$(notdir $(call spec2017_case_cfg,$(1)))"; \
 	fi
@@ -251,7 +251,7 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 		else \
 			cp "$$$$build_dir/package/spec_common/launch_multihart.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
 		fi; \
-		cp "$$(SPEC2017_LINUX_IMAGE)" "$(SPEC2017_IMAGE_DIR)/kernel/$$$$variant.Image"; \
+		MULTIHART="$$(SPEC2017_MULTIHART)" bash "$$(SPEC2017_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$$(SPEC2017_BUILDROOT_DIR)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$$$build_dir" "$(SPEC2017_IMAGE_DIR)" "$$$$variant" "$(call spec2017_case_dtb_name,$(1))"; \
 		cp "$$$$build_dir/rootfs.cpio" "$(SPEC2017_IMAGE_DIR)/rootfs/$$$$variant.rootfs.cpio"; \
 		cp "$$$$build_dir/fw_payload.bin" "$(SPEC2017_IMAGE_DIR)/bin/$$$$variant.fw_payload.bin"; \
 	done
@@ -304,7 +304,7 @@ spec2017-images: spec2017-check-spec-config
 		echo "No SPEC2017 cases selected by SPEC2017_IMAGE_INPUT=$(SPEC2017_IMAGE_INPUT) SPEC2017_IMAGE_MODE=$(SPEC2017_IMAGE_MODE)"; \
 		exit 1; \
 		fi; \
-		rm -rf "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/logs" "$(SPEC2017_IMAGE_DIR)/stamps"; \
+		rm -rf "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/dt" "$(SPEC2017_IMAGE_DIR)/manifest" "$(SPEC2017_IMAGE_DIR)/logs" "$(SPEC2017_IMAGE_DIR)/stamps"; \
 	total="$(words $(SPEC2017_IMAGE_CASES))"; \
 	i=0; \
 	for case in $(SPEC2017_IMAGE_CASES); do \

--- a/workloads/linux/spec2017/rules.mk
+++ b/workloads/linux/spec2017/rules.mk
@@ -218,17 +218,6 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 	SPEC2017_MULTIHART="$$(SPEC2017_MULTIHART)" \
 	bash "$$(abspath $$(SPEC2017_WORKLOAD_DIR))/build.sh"
 	@printf '$(SPEC2017_PROGRESS_PREFIX) Exporting $(1) split artifacts to $(SPEC2017_IMAGE_DIR)\n'
-	@mkdir -p "$(SPEC2017_IMAGE_DIR)/bin" "$(SPEC2017_IMAGE_DIR)/kernel" "$(SPEC2017_IMAGE_DIR)/elf" "$(SPEC2017_IMAGE_DIR)/cmd" "$(SPEC2017_IMAGE_DIR)/rootfs" "$(SPEC2017_IMAGE_DIR)/cfg" "$(SPEC2017_IMAGE_DIR)/gcpt" "$(SPEC2017_IMAGE_DIR)/dt" "$(SPEC2017_IMAGE_DIR)/manifest" "$(SPEC2017_IMAGE_DIR)/logs/build_elf" "$(SPEC2017_IMAGE_DIR)/stamps"
-	@if [ ! -f "$(SPEC2017_IMAGE_DIR)/cfg/$(notdir $(call spec2017_case_cfg,$(1)))" ]; then \
-		cp "$(abspath $(call spec2017_case_cfg,$(1)))" "$(SPEC2017_IMAGE_DIR)/cfg/$(notdir $(call spec2017_case_cfg,$(1)))"; \
-	fi
-	@if [ ! -f "$(SPEC2017_IMAGE_DIR)/gcpt/gcpt.elf" ] || [ ! -f "$(SPEC2017_IMAGE_DIR)/gcpt/gcpt.bin" ]; then \
-		cp "$(SPEC2017_GCPT_ELF)" "$(SPEC2017_IMAGE_DIR)/gcpt/gcpt.elf"; \
-		cp "$(SPEC2017_GCPT_BIN)" "$(SPEC2017_IMAGE_DIR)/gcpt/gcpt.bin"; \
-	fi
-	@rm -f "$(SPEC2017_IMAGE_DIR)/elf/$(1)"_*.elf
-	@cp "$(SPEC2017_BUILD_DIR)/$(1)/elf/$(1).elf" "$(SPEC2017_IMAGE_DIR)/elf/$(1).elf"
-	@cp "$(SPEC2017_BUILD_DIR)/$(1)/logs/build_elf/build.log" "$(SPEC2017_IMAGE_DIR)/logs/build_elf/$(1).log"
 	@$(SPEC2017_PYTHON) "$(SPEC2017_HELPER)" --list-packaged-variants --out-dir "$(SPEC2017_BUILD_DIR)/$(1)" | while IFS="	" read -r variant build_dir; do \
 		printf '$(SPEC2017_PROGRESS_PREFIX) Assembling firmware for %s\n' "$$$$variant"; \
 		rm -f "$$$$build_dir/rootfs.cpio"; \
@@ -246,14 +235,16 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 		SPEC2017_PROGRESS_K="$$(SPEC2017_PROGRESS_K)" \
 		SPEC2017_PROGRESS_N="$$(SPEC2017_PROGRESS_N)" \
 		bash "$$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh" "$$(SPEC2017_GCPT_BIN)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$(SPEC2017_DTS_DIR)" "$$(SPEC2017_LINUX_IMAGE)" "$$$$build_dir"; \
-		if [ -f "$$$$build_dir/package/spec/run.sh" ]; then \
-			cp "$$$$build_dir/package/spec/run.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
-		else \
-			cp "$$$$build_dir/package/spec_common/launch_multihart.sh" "$(SPEC2017_IMAGE_DIR)/cmd/$$$$variant.run.sh"; \
-		fi; \
-		MULTIHART="$$(SPEC2017_MULTIHART)" bash "$$(SPEC2017_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$$(SPEC2017_BUILDROOT_DIR)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$$$build_dir" "$(SPEC2017_IMAGE_DIR)" "$$$$variant" "$(call spec2017_case_dtb_name,$(1))"; \
-		cp "$$$$build_dir/rootfs.cpio" "$(SPEC2017_IMAGE_DIR)/rootfs/$$$$variant.rootfs.cpio"; \
-		cp "$$$$build_dir/fw_payload.bin" "$(SPEC2017_IMAGE_DIR)/bin/$$$$variant.fw_payload.bin"; \
+		run_command="$$$$build_dir/package/spec/run.sh"; \
+		if [ ! -f "$$$$run_command" ]; then run_command="$$$$build_dir/package/spec_common/launch_multihart.sh"; fi; \
+		MULTIHART="$$(SPEC2017_MULTIHART)" \
+		WORKLOAD_ELF="$$(SPEC2017_BUILD_DIR)/$(1)/elf/$(1).elf" \
+		BUILD_LOG="$$(SPEC2017_BUILD_DIR)/$(1)/logs/build_elf/build.log" \
+		RUN_COMMAND="$$$$run_command" \
+		SPEC_CONFIG="$(abspath $(call spec2017_case_cfg,$(1)))" \
+		GCPT_ELF="$$(SPEC2017_GCPT_ELF)" \
+		GCPT_BIN="$$(SPEC2017_GCPT_BIN)" \
+		bash "$$(SPEC2017_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$$(SPEC2017_BUILDROOT_DIR)" "$$(SPEC2017_SBI_BUILD_DIR)" "$$$$build_dir" "$(SPEC2017_IMAGE_DIR)" "$$$$variant" "$(call spec2017_case_dtb_name,$(1))"; \
 	done
 	@touch "$$@"
 endef

--- a/workloads/linux/spec2026/README.md
+++ b/workloads/linux/spec2026/README.md
@@ -34,28 +34,48 @@ The export tree is:
 ```text
 build/images/spec2026rate/
   bin/<case>.fw_payload.bin
-  kernel/<case>.Image
+  kernel/<case>.vmlinux
+  kernel/<case>.System.map
+  kernel/<case>.config
   rootfs/<case>.rootfs.cpio
+  dt/<case>.dtb
+  dt/<case>.dts
   elf/<case>.elf
   cmd/<case>.run.sh
   gcpt/gcpt.elf
   gcpt/gcpt.bin
+  opensbi/fw_jump.elf
+  opensbi/defconfig
+  manifest/<case>.json
   cfg/<cfg>.cfg
   logs/build_elf/<case>.log
   stamps/<case>.images.stamp
 
 build/images/spec2026speed/
   bin/<case>.fw_payload.bin
-  kernel/<case>.Image
+  kernel/<case>.vmlinux
+  kernel/<case>.System.map
+  kernel/<case>.config
   rootfs/<case>.rootfs.cpio
+  dt/<case>.dtb
+  dt/<case>.dts
   elf/<case>.elf
   cmd/<case>.run.sh
   gcpt/gcpt.elf
   gcpt/gcpt.bin
+  opensbi/fw_jump.elf
+  opensbi/defconfig
+  manifest/<case>.json
   cfg/<cfg>.cfg
   logs/build_elf/<case>.log
   stamps/<case>.images.stamp
 ```
+
+`bin/` is the directly loadable firmware image and `rootfs/` is its initramfs.
+`kernel/` contains the ELF kernel plus its symbol map and configuration for
+debugging; `dt/` contains the exact DTB and generated DTS used by each case.
+`manifest/` records component hashes and load addresses. `gcpt/`, `cfg/`, and
+`opensbi/` are shared by the export tree.
 
 Useful selectors:
 

--- a/workloads/linux/spec2026/rules.mk
+++ b/workloads/linux/spec2026/rules.mk
@@ -163,15 +163,15 @@ linux/$(1): $(SPEC2026_BUILD_DIR)/$(1)/fw_payload.bin
 
 WORKLOAD_PHONY_TARGETS += linux/$(1)
 
-$(call spec2026_case_image_stamp,$(1)): $(SPEC2026_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2026_GCPT_ELF) $(SPEC2026_GCPT_BIN) $(SPEC2026_LINUX_IMAGE) | spec2026-check-spec-iso
+$(call spec2026_case_image_stamp,$(1)): $(SPEC2026_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2026_GCPT_ELF) $(SPEC2026_GCPT_BIN) $(SPEC2026_LINUX_IMAGE) $(SPEC2026_SBI_BIN) $$(SPEC2026_SCRIPTS_DIR)/export-linux-debug-artifacts.sh | spec2026-check-spec-iso
 	@printf '$(SPEC2026_PROGRESS_PREFIX) Exporting $(1) artifacts to $(call spec2026_case_image_dir,$(1))\n'
-	@mkdir -p "$(call spec2026_case_image_dir,$(1))/bin" "$(call spec2026_case_image_dir,$(1))/kernel" "$(call spec2026_case_image_dir,$(1))/rootfs" "$(call spec2026_case_image_dir,$(1))/elf" "$(call spec2026_case_image_dir,$(1))/cmd" "$(call spec2026_case_image_dir,$(1))/cfg" "$(call spec2026_case_image_dir,$(1))/gcpt" "$(call spec2026_case_image_dir,$(1))/logs/build_elf" "$(call spec2026_case_image_dir,$(1))/stamps"
+	@mkdir -p "$(call spec2026_case_image_dir,$(1))/bin" "$(call spec2026_case_image_dir,$(1))/kernel" "$(call spec2026_case_image_dir,$(1))/rootfs" "$(call spec2026_case_image_dir,$(1))/elf" "$(call spec2026_case_image_dir,$(1))/cmd" "$(call spec2026_case_image_dir,$(1))/cfg" "$(call spec2026_case_image_dir,$(1))/gcpt" "$(call spec2026_case_image_dir,$(1))/dt" "$(call spec2026_case_image_dir,$(1))/manifest" "$(call spec2026_case_image_dir,$(1))/logs/build_elf" "$(call spec2026_case_image_dir,$(1))/stamps"
 	@cp "$(SPEC2026_CFG)" "$(call spec2026_case_image_dir,$(1))/cfg/$(notdir $(SPEC2026_CFG))"
 	@cp "$(SPEC2026_GCPT_ELF)" "$(call spec2026_case_image_dir,$(1))/gcpt/gcpt.elf"
 	@cp "$(SPEC2026_GCPT_BIN)" "$(call spec2026_case_image_dir,$(1))/gcpt/gcpt.bin"
 	@cp "$(SPEC2026_BUILD_DIR)/$(1)/elf/$(1).elf" "$(call spec2026_case_image_dir,$(1))/elf/$(1).elf"
 	@cp "$(SPEC2026_BUILD_DIR)/$(1)/logs/build_elf/build.log" "$(call spec2026_case_image_dir,$(1))/logs/build_elf/$(1).log"
-	@cp "$(SPEC2026_LINUX_IMAGE)" "$(call spec2026_case_image_dir,$(1))/kernel/$(1).Image"
+	@MULTIHART="$(SPEC2026_MULTIHART)" bash "$(SPEC2026_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$(SPEC2026_BUILDROOT_DIR)" "$(SPEC2026_SBI_BUILD_DIR)" "$(SPEC2026_BUILD_DIR)/$(1)" "$(call spec2026_case_image_dir,$(1))" "$(1)" "$(call spec2026_case_dtb_name,$(1))"
 	@cp "$(SPEC2026_BUILD_DIR)/$(1)/rootfs.cpio" "$(call spec2026_case_image_dir,$(1))/rootfs/$(1).rootfs.cpio"
 	@cp "$(SPEC2026_BUILD_DIR)/$(1)/fw_payload.bin" "$(call spec2026_case_image_dir,$(1))/bin/$(1).fw_payload.bin"
 	@cp "$(SPEC2026_BUILD_DIR)/$(1)/package/spec/run.sh" "$(call spec2026_case_image_dir,$(1))/cmd/$(1).run.sh"
@@ -212,7 +212,7 @@ spec2026-images: spec2026-check-spec-iso
 		echo "No SPEC2026 cases selected by SPEC2026_IMAGE_INPUT=$(SPEC2026_IMAGE_INPUT), SPEC2026_IMAGE_MODE=$(SPEC2026_IMAGE_MODE)"; \
 		exit 1; \
 	fi; \
-	rm -rf "$(SPEC2026_IMAGE_DIR)/bin" "$(SPEC2026_IMAGE_DIR)/kernel" "$(SPEC2026_IMAGE_DIR)/rootfs" "$(SPEC2026_IMAGE_DIR)/elf" "$(SPEC2026_IMAGE_DIR)/cmd" "$(SPEC2026_IMAGE_DIR)/cfg" "$(SPEC2026_IMAGE_DIR)/gcpt" "$(SPEC2026_IMAGE_DIR)/logs" "$(SPEC2026_IMAGE_DIR)/stamps"; \
+	rm -rf "$(SPEC2026_IMAGE_DIR)/bin" "$(SPEC2026_IMAGE_DIR)/kernel" "$(SPEC2026_IMAGE_DIR)/rootfs" "$(SPEC2026_IMAGE_DIR)/elf" "$(SPEC2026_IMAGE_DIR)/cmd" "$(SPEC2026_IMAGE_DIR)/cfg" "$(SPEC2026_IMAGE_DIR)/gcpt" "$(SPEC2026_IMAGE_DIR)/dt" "$(SPEC2026_IMAGE_DIR)/manifest" "$(SPEC2026_IMAGE_DIR)/logs" "$(SPEC2026_IMAGE_DIR)/stamps"; \
 	total="$(words $(SPEC2026_IMAGE_CASES))"; \
 	i=0; \
 	for case in $(SPEC2026_IMAGE_CASES); do \

--- a/workloads/linux/spec2026/rules.mk
+++ b/workloads/linux/spec2026/rules.mk
@@ -165,16 +165,14 @@ WORKLOAD_PHONY_TARGETS += linux/$(1)
 
 $(call spec2026_case_image_stamp,$(1)): $(SPEC2026_BUILD_DIR)/$(1)/fw_payload.bin $(SPEC2026_GCPT_ELF) $(SPEC2026_GCPT_BIN) $(SPEC2026_LINUX_IMAGE) $(SPEC2026_SBI_BIN) $$(SPEC2026_SCRIPTS_DIR)/export-linux-debug-artifacts.sh | spec2026-check-spec-iso
 	@printf '$(SPEC2026_PROGRESS_PREFIX) Exporting $(1) artifacts to $(call spec2026_case_image_dir,$(1))\n'
-	@mkdir -p "$(call spec2026_case_image_dir,$(1))/bin" "$(call spec2026_case_image_dir,$(1))/kernel" "$(call spec2026_case_image_dir,$(1))/rootfs" "$(call spec2026_case_image_dir,$(1))/elf" "$(call spec2026_case_image_dir,$(1))/cmd" "$(call spec2026_case_image_dir,$(1))/cfg" "$(call spec2026_case_image_dir,$(1))/gcpt" "$(call spec2026_case_image_dir,$(1))/dt" "$(call spec2026_case_image_dir,$(1))/manifest" "$(call spec2026_case_image_dir,$(1))/logs/build_elf" "$(call spec2026_case_image_dir,$(1))/stamps"
-	@cp "$(SPEC2026_CFG)" "$(call spec2026_case_image_dir,$(1))/cfg/$(notdir $(SPEC2026_CFG))"
-	@cp "$(SPEC2026_GCPT_ELF)" "$(call spec2026_case_image_dir,$(1))/gcpt/gcpt.elf"
-	@cp "$(SPEC2026_GCPT_BIN)" "$(call spec2026_case_image_dir,$(1))/gcpt/gcpt.bin"
-	@cp "$(SPEC2026_BUILD_DIR)/$(1)/elf/$(1).elf" "$(call spec2026_case_image_dir,$(1))/elf/$(1).elf"
-	@cp "$(SPEC2026_BUILD_DIR)/$(1)/logs/build_elf/build.log" "$(call spec2026_case_image_dir,$(1))/logs/build_elf/$(1).log"
-	@MULTIHART="$(SPEC2026_MULTIHART)" bash "$(SPEC2026_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$(SPEC2026_BUILDROOT_DIR)" "$(SPEC2026_SBI_BUILD_DIR)" "$(SPEC2026_BUILD_DIR)/$(1)" "$(call spec2026_case_image_dir,$(1))" "$(1)" "$(call spec2026_case_dtb_name,$(1))"
-	@cp "$(SPEC2026_BUILD_DIR)/$(1)/rootfs.cpio" "$(call spec2026_case_image_dir,$(1))/rootfs/$(1).rootfs.cpio"
-	@cp "$(SPEC2026_BUILD_DIR)/$(1)/fw_payload.bin" "$(call spec2026_case_image_dir,$(1))/bin/$(1).fw_payload.bin"
-	@cp "$(SPEC2026_BUILD_DIR)/$(1)/package/spec/run.sh" "$(call spec2026_case_image_dir,$(1))/cmd/$(1).run.sh"
+	@MULTIHART="$(SPEC2026_MULTIHART)" \
+	WORKLOAD_ELF="$(SPEC2026_BUILD_DIR)/$(1)/elf/$(1).elf" \
+	BUILD_LOG="$(SPEC2026_BUILD_DIR)/$(1)/logs/build_elf/build.log" \
+	RUN_COMMAND="$(SPEC2026_BUILD_DIR)/$(1)/package/spec/run.sh" \
+	SPEC_CONFIG="$(SPEC2026_CFG)" \
+	GCPT_ELF="$(SPEC2026_GCPT_ELF)" \
+	GCPT_BIN="$(SPEC2026_GCPT_BIN)" \
+	bash "$(SPEC2026_SCRIPTS_DIR)/export-linux-debug-artifacts.sh" "$(SPEC2026_BUILDROOT_DIR)" "$(SPEC2026_SBI_BUILD_DIR)" "$(SPEC2026_BUILD_DIR)/$(1)" "$(call spec2026_case_image_dir,$(1))" "$(1)" "$(call spec2026_case_dtb_name,$(1))"
 	@touch "$$@"
 endef
 


### PR DESCRIPTION
- Replace exported raw kernel `Image` files with disassemblable `vmlinux`.
- Export `System.map`, kernel `.config`, and the selected DTB/DTS per case.
- Export OpenSBI `fw_jump.elf` and its `defconfig`.
- Add per-case manifests containing component paths, SHA256 hashes, and load addresses.
- Document the expanded image directory layout for SPEC2006, SPEC2017, and SPEC2026.