### PR TITLE
feat(multihart): add riscv isa extensions for multihart workloads

### DIFF
--- a/dts/README.md
+++ b/dts/README.md
@@ -99,9 +99,15 @@ python3 scripts/generate-xiangshan-multihart-dts.py \
 
 `--harts` must be in the range 2 through 128. The generator copies the CPU node for each hart,
 extends the CLINT, PLIC, and debug interrupt contexts, and applies the NEMU
-UARTLITE and PLIC settings. It normalizes every generated CPU to
-`riscv,isa = "rv64imafdc"`. Generated multi-hart templates reserve the fixed
+UARTLITE and PLIC settings. Generated multi-hart templates reserve the fixed
 131 MiB checkpoint window `[0x80300000, 0x88600000)`.
+
+The full capability block describes XiangShan hardware and is not fully
+emulated by the current QEMU `nemu` machine. In particular, DT-advertised
+`smrnmi` requires an OpenSBI platform `smrnmi_handlers_init` callback, while
+the `nemu` timer path cannot execute the DT-advertised `sstc` CSR sequence.
+The current multi-core DTB must omit `smrnmi` and `sstc` and run with
+`sstc=false`.
 
 The build does not invoke this generator automatically. Run it and review the
 result before building with the corresponding `HARTS` value.

--- a/dts/xiangshan-fpga-noAIA-2hart-mem8g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-2hart-mem8g.dts.in
@@ -43,7 +43,29 @@
 			 * workload template while using the FPGA board interrupt/peripheral
 			 * map below.
 			 */
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions =
+				"i", "m", "a", "f", "d", "c", "v", "h",
+				"sdtrig", "sha", "shcounterenw", "shgatpa",
+				"shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+				"shvstvecd", "smcsrind", "smdbltrp",
+				"smmpm", "smnpm", "smstateen",
+				"ss1p13", "ssccptr", "sscofpmf",
+				"sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+				"sspm", "ssstateen", "ssstrict",
+				"sstvala", "sstvecd", "ssu64xl", "supm",
+				"sv39", "sv48", "svade", "svbare", "svinval",
+				"svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+				"zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+				"zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+				"zic64b",
+				"ziccamoa", "ziccif", "zicclsm", "ziccrse",
+				"zicntr", "zicond", "zicsr", "zifencei",
+				"zihintntl", "zihintpause", "zihpm", "zimop",
+				"zkn", "zknd", "zkne", "zknh", "zksed",
+				"zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+				"zvkt", "zvl128b", "zvl32b", "zvl64b";
 			riscv,cbom-block-size = <0x40>;
 			riscv,cboz-block-size = <0x40>;
 
@@ -82,7 +104,29 @@
 			 * workload template while using the FPGA board interrupt/peripheral
 			 * map below.
 			 */
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions =
+				"i", "m", "a", "f", "d", "c", "v", "h",
+				"sdtrig", "sha", "shcounterenw", "shgatpa",
+				"shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+				"shvstvecd", "smcsrind", "smdbltrp",
+				"smmpm", "smnpm", "smstateen",
+				"ss1p13", "ssccptr", "sscofpmf",
+				"sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+				"sspm", "ssstateen", "ssstrict",
+				"sstvala", "sstvecd", "ssu64xl", "supm",
+				"sv39", "sv48", "svade", "svbare", "svinval",
+				"svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+				"zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+				"zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+				"zic64b",
+				"ziccamoa", "ziccif", "zicclsm", "ziccrse",
+				"zicntr", "zicond", "zicsr", "zifencei",
+				"zihintntl", "zihintpause", "zihpm", "zimop",
+				"zkn", "zknd", "zkne", "zknh", "zksed",
+				"zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+				"zvkt", "zvl128b", "zvl32b", "zvl64b";
 			riscv,cbom-block-size = <0x40>;
 			riscv,cboz-block-size = <0x40>;
 

--- a/dts/xiangshan-fpga-noAIA-32hart-mem64g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-32hart-mem64g.dts.in
@@ -38,7 +38,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu0_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -57,7 +57,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu1_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -76,7 +76,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu2_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -95,7 +95,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu3_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -114,7 +114,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu4_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -133,7 +133,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu5_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -152,7 +152,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu6_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -171,7 +171,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu7_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -190,7 +190,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu8_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -209,7 +209,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu9_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -228,7 +228,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu10_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -247,7 +247,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu11_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -266,7 +266,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu12_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -285,7 +285,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu13_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -304,7 +304,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu14_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -323,7 +323,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu15_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -342,7 +342,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu16_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -361,7 +361,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu17_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -380,7 +380,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu18_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -399,7 +399,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu19_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -418,7 +418,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu20_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -437,7 +437,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu21_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -456,7 +456,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu22_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -475,7 +475,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu23_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -494,7 +494,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu24_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -513,7 +513,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu25_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -532,7 +532,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu26_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -551,7 +551,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu27_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -570,7 +570,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu28_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -589,7 +589,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu29_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -608,7 +608,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu30_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -627,7 +627,7 @@
             riscv,cboz-block-size = <64>;
             riscv,isa = "rv64imafdcv_zicbom_zicboz";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
 
             cpu31_intc: interrupt-controller {
                 #interrupt-cells = <1>;

--- a/dts/xiangshan-fpga-noAIA-32hart-mem64g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-32hart-mem64g.dts.in
@@ -36,9 +36,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu0_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -55,9 +75,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu1_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -74,9 +114,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu2_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -93,9 +153,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu3_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -112,9 +192,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu4_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -131,9 +231,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu5_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -150,9 +270,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu6_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -169,9 +309,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu7_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -188,9 +348,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu8_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -207,9 +387,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu9_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -226,9 +426,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu10_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -245,9 +465,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu11_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -264,9 +504,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu12_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -283,9 +543,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu13_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -302,9 +582,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu14_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -321,9 +621,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu15_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -340,9 +660,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu16_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -359,9 +699,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu17_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -378,9 +738,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu18_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -397,9 +777,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu19_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -416,9 +816,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu20_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -435,9 +855,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu21_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -454,9 +894,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu22_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -473,9 +933,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu23_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -492,9 +972,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu24_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -511,9 +1011,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu25_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -530,9 +1050,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu26_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -549,9 +1089,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu27_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -568,9 +1128,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu28_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -587,9 +1167,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu29_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -606,9 +1206,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu30_intc: interrupt-controller {
                 #interrupt-cells = <1>;
@@ -625,9 +1245,29 @@
             riscv,cbom-block-size = <64>;
             riscv,cbop-block-size = <64>;
             riscv,cboz-block-size = <64>;
-            riscv,isa = "rv64imafdcv_zicbom_zicboz";
+            riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
             riscv,isa-base = "rv64i";
-            riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "supm", "zba", "zbb", "zbs", "zca", "zcb", "zcmop", "zfa", "zfhmin", "zicbop", "zicbom", "zicboz", "zicntr", "zicond", "zicsr", "zihpm", "zihintpause", "zihintntl", "zimop", "zkt", "zvbb", "zvfhmin", "zvkt";
+            riscv,isa-extensions =
+                "i", "m", "a", "f", "d", "c", "v", "h",
+                "sdtrig", "sha", "shcounterenw", "shgatpa",
+                "shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+                "shvstvecd", "smcsrind", "smdbltrp",
+                "smmpm", "smnpm", "smstateen",
+                "ss1p13", "ssccptr", "sscofpmf",
+                "sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+                "sspm", "ssstateen", "ssstrict",
+                "sstvala", "sstvecd", "ssu64xl", "supm",
+                "sv39", "sv48", "svade", "svbare", "svinval",
+                "svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+                "zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+                "zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+                "zic64b",
+                "ziccamoa", "ziccif", "zicclsm", "ziccrse",
+                "zicntr", "zicond", "zicsr", "zifencei",
+                "zihintntl", "zihintpause", "zihpm", "zimop",
+                "zkn", "zknd", "zkne", "zknh", "zksed",
+                "zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+                "zvkt", "zvl128b", "zvl32b", "zvl64b";
 
             cpu31_intc: interrupt-controller {
                 #interrupt-cells = <1>;

--- a/scripts/build-firmware-linux.sh
+++ b/scripts/build-firmware-linux.sh
@@ -124,7 +124,7 @@ check_dtb_memory_layout() {
     fi
 }
 
-check_multihart_cpu_count() {
+check_dtb_cpu_count() {
     local dts_file="$1"
     local expected_harts="$2"
     local actual_harts
@@ -279,10 +279,12 @@ if ! [ -f "$DEFAULT_DTS_FILE" ]; then
     echo "Default device tree source not found: $DEFAULT_DTS_FILE" >&2
     exit 1
 fi
+expected_harts=1
 if [ "${MULTIHART:-0}" = 1 ]; then
-    check_multihart_cpu_count "$DEFAULT_DTS_FILE" "$HARTS"
+    expected_harts="$HARTS"
     check_multihart_checkpoint_reservation "$DEFAULT_DTS_FILE"
 fi
+check_dtb_cpu_count "$DEFAULT_DTS_FILE" "$expected_harts"
 check_dtb_memory_layout "$DEFAULT_DTS_FILE" "$DTB_MIN_MEMORY_BYTES"
 SBI_IMAGE="$SBI_BUILD_DIR/build/platform/generic/firmware/fw_jump.bin"
 if [ "${MULTIHART:-0}" = 1 ]; then

--- a/scripts/generate-xiangshan-multihart-dts.py
+++ b/scripts/generate-xiangshan-multihart-dts.py
@@ -4,7 +4,35 @@ import re
 from pathlib import Path
 
 
-MULTIHART_RISCV_ISA = "rv64imafdc"
+MULTIHART_RISCV_ISA = (
+    "rv64imafdcvh_smstateen_sscofpmf_sstc_zicntr_zihpm_svpbmt_"
+    "sdtrig_smcsrind_sscsrind_svade"
+)
+MULTIHART_CPU_ISA_PROPERTIES = f"""\
+\t\t\triscv,isa = "{MULTIHART_RISCV_ISA}";
+\t\t\triscv,isa-base = "rv64i";
+\t\t\triscv,isa-extensions =
+\t\t\t\t"i", "m", "a", "f", "d", "c", "v", "h",
+\t\t\t\t"sdtrig", "sha", "shcounterenw", "shgatpa",
+\t\t\t\t"shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+\t\t\t\t"shvstvecd", "smcsrind", "smdbltrp",
+\t\t\t\t"smmpm", "smnpm", "smrnmi", "smstateen",
+\t\t\t\t"ss1p13", "ssccptr", "sscofpmf",
+\t\t\t\t"sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+\t\t\t\t"sspm", "ssstateen", "ssstrict", "sstc",
+\t\t\t\t"sstvala", "sstvecd", "ssu64xl", "supm",
+\t\t\t\t"sv39", "sv48", "svade", "svbare", "svinval",
+\t\t\t\t"svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+\t\t\t\t"zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+\t\t\t\t"zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+\t\t\t\t"zic64b",
+\t\t\t\t"ziccamoa", "ziccif", "zicclsm", "ziccrse",
+\t\t\t\t"zicntr", "zicond", "zicsr", "zifencei",
+\t\t\t\t"zihintntl", "zihintpause", "zihpm", "zimop",
+\t\t\t\t"zkn", "zknd", "zkne", "zknh", "zksed",
+\t\t\t\t"zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+\t\t\t\t"zvkt", "zvl128b", "zvl32b", "zvl64b";
+"""
 MAX_HARTS = 128
 CHECKPOINT_RESERVED_NODE = """
 
@@ -57,7 +85,7 @@ def cpu_node(cpu0_node, hart):
 
 def normalize_cpu_isa(cpu_node_text):
     normalized, replacements = CPU_ISA_PROPERTIES.subn(
-        f'\t\t\triscv,isa = "{MULTIHART_RISCV_ISA}";\n', cpu_node_text, count=1
+        MULTIHART_CPU_ISA_PROPERTIES, cpu_node_text, count=1
     )
     if replacements != 1:
         raise RuntimeError("CPU node does not contain the expected ISA properties")


### PR DESCRIPTION
Align 2harts and 32harts DTB with single hart DTB isa, note that the current multi-core DTB must omit `smrnmi` and `sstc` due to QEMU.