### PR TITLE
fix(spec2017):change multihart default dtb to 16GB

### DIFF
--- a/dts/xiangshan-fpga-noAIA-2hart-mem16g.dts.in
+++ b/dts/xiangshan-fpga-noAIA-2hart-mem16g.dts.in
@@ -1,0 +1,243 @@
+/*
+ * XiangShan FPGA DTS used by the fpga board flow.
+ *
+ * 1. AIA is disabled, so Linux should only see the legacy CLINT + PLIC path.
+ * 2. QEMU/NEMU UARTLITE is exposed as the serial console.
+ */
+
+/dts-v1/;
+
+/ {
+	compatible = "freechips,rocketchip-unknown-dev";
+	model = "xiangshan,Kunminghu-dev";
+	#address-cells = <2>;
+	#size-cells = <2>;
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+
+		cpu0: cpu@0 {
+			compatible = "ICT,xiangshan", "riscv";
+			device_type = "cpu";
+			reg = <0x0>;
+			status = "okay";
+
+			d-cache-block-size = <64>;
+			d-cache-sets = <256>;
+			d-cache-size = <65536>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <48>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <256>;
+			i-cache-size = <65536>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <48>;
+			mmu-type = "riscv,sv48";
+			clock-frequency = <0>;
+			timebase-frequency = <1000000>;
+			tlb-split;
+
+			/*
+			 * Keep the Linux-friendly CPU capability description from the
+			 * workload template while using the FPGA board interrupt/peripheral
+			 * map below.
+			 */
+			riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions =
+				"i", "m", "a", "f", "d", "c", "v", "h",
+				"sdtrig", "sha", "shcounterenw", "shgatpa",
+				"shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+				"shvstvecd", "smcsrind", "smdbltrp",
+				"smmpm", "smnpm", "smstateen",
+				"ss1p13", "ssccptr", "sscofpmf",
+				"sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+				"sspm", "ssstateen", "ssstrict",
+				"sstvala", "sstvecd", "ssu64xl", "supm",
+				"sv39", "sv48", "svade", "svbare", "svinval",
+				"svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+				"zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+				"zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+				"zic64b",
+				"ziccamoa", "ziccif", "zicclsm", "ziccrse",
+				"zicntr", "zicond", "zicsr", "zifencei",
+				"zihintntl", "zihintpause", "zihpm", "zimop",
+				"zkn", "zknd", "zkne", "zknh", "zksed",
+				"zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+				"zvkt", "zvl128b", "zvl32b", "zvl64b";
+			riscv,cbom-block-size = <0x40>;
+			riscv,cboz-block-size = <0x40>;
+
+			next-level-cache = <&l2_cache>;
+
+			intc_cpu0: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+
+		cpu1: cpu@1 {
+			compatible = "ICT,xiangshan", "riscv";
+			device_type = "cpu";
+			reg = <0x1>;
+			status = "okay";
+
+			d-cache-block-size = <64>;
+			d-cache-sets = <256>;
+			d-cache-size = <65536>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <48>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <256>;
+			i-cache-size = <65536>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <48>;
+			mmu-type = "riscv,sv48";
+			clock-frequency = <0>;
+			timebase-frequency = <1000000>;
+			tlb-split;
+
+			/*
+			 * Keep the Linux-friendly CPU capability description from the
+			 * workload template while using the FPGA board interrupt/peripheral
+			 * map below.
+			 */
+			riscv,isa = "rv64imafdcvh_smstateen_sscofpmf_zicntr_zihpm_svpbmt_sdtrig_smcsrind_sscsrind_svade";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions =
+				"i", "m", "a", "f", "d", "c", "v", "h",
+				"sdtrig", "sha", "shcounterenw", "shgatpa",
+				"shlcofideleg", "shtvala", "shvsatpa", "shvstvala",
+				"shvstvecd", "smcsrind", "smdbltrp",
+				"smmpm", "smnpm", "smstateen",
+				"ss1p13", "ssccptr", "sscofpmf",
+				"sscounterenw", "sscsrind", "ssdbltrp", "ssnpm",
+				"sspm", "ssstateen", "ssstrict",
+				"sstvala", "sstvecd", "ssu64xl", "supm",
+				"sv39", "sv48", "svade", "svbare", "svinval",
+				"svnapot", "svpbmt", "za64rs", "zacas", "zawrs",
+				"zba", "zbb", "zbc", "zbkb", "zbkc", "zbkx",
+				"zbs", "zca", "zcb", "zcmop", "zfa", "zfh", "zfhmin",
+				"zic64b",
+				"ziccamoa", "ziccif", "zicclsm", "ziccrse",
+				"zicntr", "zicond", "zicsr", "zifencei",
+				"zihintntl", "zihintpause", "zihpm", "zimop",
+				"zkn", "zknd", "zkne", "zknh", "zksed",
+				"zksh", "zkt", "zvbb", "zvfh", "zvfhmin",
+				"zvkt", "zvl128b", "zvl32b", "zvl64b";
+			riscv,cbom-block-size = <0x40>;
+			riscv,cboz-block-size = <0x40>;
+
+			next-level-cache = <&l2_cache>;
+
+			intc_cpu1: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+
+	l2_cache: l2-cache {
+		compatible = "cache";
+		cache-level = <2>;
+		cache-block-size = <64>;
+		cache-size = <1048576>;
+	};
+
+	memory: memory@80000000 {
+		device_type = "memory";
+		/*
+		 * Static 16 GiB memory profile for multi-hart workloads.
+		 */
+		reg = <0x0 0x80000000 0x4 0x00000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved0: buffer@0 {
+			no-map;
+			reg = <0x0 0x80000000 0x0 0x100000>;
+		};
+
+		/* Keep the 131 MiB QEMU checkpoint window out of Linux memory. */
+		checkpoint: checkpoint@80300000 {
+			no-map;
+			reg = <0x0 0x80300000 0x0 0x08300000>;
+		};
+	};
+
+	soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		compatible = "freechips,rocketchip-unknown-soc", "simple-bus";
+		ranges;
+
+		/*
+		 * This FPGA image boots without AIA. Describe only the CLINT + PLIC
+		 * interrupt topology that the software stack should probe.
+		 */
+		clint: clint@38000000 {
+			compatible = "riscv,clint0";
+			reg = <0x0 0x38000000 0x0 0x10000>;
+			reg-names = "control";
+			interrupts-extended = <&intc_cpu0 3 &intc_cpu0 7 &intc_cpu1 3 &intc_cpu1 7>;
+		};
+
+		debug-controller@38020000 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			debug-attach = "jtag";
+			reg = <0x0 0x38020000 0x0 0x1000>;
+			reg-names = "control";
+			interrupts-extended = <&intc_cpu0 65535 &intc_cpu1 65535>;
+		};
+
+		PLIC: interrupt-controller@3c000000 {
+			compatible = "riscv,plic0";
+			#interrupt-cells = <1>;
+			interrupt-controller;
+			reg = <0x0 0x3c000000 0x0 0x4000000>;
+			reg-names = "control";
+			interrupts-extended = <&intc_cpu0 11 &intc_cpu0 9 &intc_cpu1 11 &intc_cpu1 9>;
+			riscv,max-priority = <7>;
+			riscv,ndev = <64>;
+		};
+
+		/*
+		 * QEMU/NEMU exposes UARTLITE at 0x40600000.
+		 */
+		uart0: serial@40600000 {
+			compatible = "xlnx,xps-uartlite-1.00.a";
+			interrupt-parent = <&PLIC>;
+			interrupts = <3>;
+			current-speed = <115200>;
+			reg = <0x0 0x40600000 0x0 0x1000>;
+			reg-names = "control";
+			status = "okay";
+		};
+	};
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	chosen {
+		/*
+		 * Keep the SBI console as the primary console under QEMU/NEMU.
+		 */
+		bootargs = "console=hvc0 earlycon=sbi loglevel=8";
+		stdout-path = "serial0:115200n8";
+		linux,initrd-start = <INITRAMFS_BEGIN_HI INITRAMFS_BEGIN_LO>;
+		linux,initrd-end = <INITRAMFS_END_HI INITRAMFS_END_LO>;
+
+		opensbi-config {
+			compatible = "opensbi,config";
+			cold-boot-harts = <&cpu0>;
+		};
+	};
+};

--- a/workloads/linux/spec2017/README.md
+++ b/workloads/linux/spec2017/README.md
@@ -33,7 +33,7 @@ matching multi-hart DTS template explicitly:
 make linux/spec2017 BENCH=mcf MODE=rate INPUT=ref \
   SPEC2017_ISO=/path/to/cpu2017.iso \
   MULTIHART=1 HARTS=2 \
-  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem16g -jN
 ```
 
 The same options apply to split image exports:
@@ -42,7 +42,7 @@ The same options apply to split image exports:
 make spec2017-images BENCH=mcf MODE=rate INPUT=ref \
   SPEC2017_ISO=/path/to/cpu2017.iso \
   MULTIHART=1 HARTS=2 \
-  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g -jN
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem16g -jN
 ```
 
 The package step creates `/spec0` through `/spec<N-1>` and starts one copy on
@@ -51,10 +51,11 @@ each hart through `/spec_common/launch_multihart.sh`. Each hart uses its own
 the launcher reports the aggregate exit status.
 
 `DEFAULT_DTB` is required for multi-hart builds and must be the complete DTS
-basename without `.dts.in`. Its CPU count must match `HARTS`. SPEC2017 also
-retains its memory-size checks: rate cases require at least 8 GiB and speed
-cases require at least 24 GiB, so select or generate a matching multi-hart
-template with sufficient memory.
+basename without `.dts.in`. Its CPU count must match `HARTS`. Every multi-hart
+SPEC2017 DTB must describe at least 16 GiB. The existing mode checks still
+apply as well: rate cases require at least 8 GiB and speed cases require at
+least 24 GiB. Thus `xiangshan-fpga-noAIA-2hart-mem16g` is valid for rate mode;
+speed mode still needs a larger profile such as 24 GiB.
 
 The ISO is extracted and installed through a temporary local staging directory,
 then copied into the writable workspace
@@ -199,7 +200,9 @@ make linux/spec2017 BENCH=x264 MODE=speed INPUT=ref \
   SPEC2017_ISO=/path/to/cpu2017.iso -jN
 ```
 
-The minimum checked size is 8 GiB for rate cases and 24 GiB for speed cases.
+The mode-specific minimum is 8 GiB for rate cases and 24 GiB for speed cases.
+Multi-hart builds additionally require at least 16 GiB, so both checks must
+pass.
 
 The source templates live in:
 

--- a/workloads/linux/spec2017/rules.mk
+++ b/workloads/linux/spec2017/rules.mk
@@ -33,6 +33,7 @@ SPEC2017_SPEED_DTB_MEMORY ?= 24g
 SPEC2017_DTB_MEMORY ?=
 SPEC2017_RATE_DTB_MIN_MEMORY_BYTES ?= 8589934592
 SPEC2017_SPEED_DTB_MIN_MEMORY_BYTES ?= 25769803776
+override SPEC2017_MULTIHART_DTB_REQUIRED_MIN_MEMORY_BYTES := 17179869184
 SPEC2017_PROFILING ?= $(if $(PROFILING),$(PROFILING),1)
 SPEC2017_TUNE ?= base
 SPEC2017_JOBS ?= $(shell nproc)
@@ -56,6 +57,7 @@ spec2017_case_dtb_profile = $(if $(SPEC2017_EXPLICIT_DEFAULT_DTB),,$(call spec20
 spec2017_case_dtb_name = $(if $(call spec2017_case_dtb_profile,$(1)),$(if $(filter %-novec,$(SPEC2017_DEFAULT_DTB)),$(patsubst %-novec,%,$(SPEC2017_DEFAULT_DTB))-mem$(call spec2017_case_dtb_profile,$(1))-novec,$(SPEC2017_DEFAULT_DTB)-mem$(call spec2017_case_dtb_profile,$(1))),$(SPEC2017_DEFAULT_DTB))
 spec2017_case_dtb_tag = $(subst /,_,$(call spec2017_case_dtb_name,$(1)))
 spec2017_case_dtb_min_memory_bytes = $(if $(findstring _speed_,$(1)),$(SPEC2017_SPEED_DTB_MIN_MEMORY_BYTES),$(SPEC2017_RATE_DTB_MIN_MEMORY_BYTES))
+spec2017_case_dtb_required_min_memory_bytes = $(if $(filter 1,$(SPEC2017_MULTIHART)),$(SPEC2017_MULTIHART_DTB_REQUIRED_MIN_MEMORY_BYTES),)
 spec2017_case_cfg = $(if $(SPEC2017_EXPLICIT_CFG),$(SPEC2017_CFG),$(if $(findstring _speed_,$(1)),$(SPEC2017_SPEED_CFG),$(SPEC2017_RATE_CFG)))
 spec2017_case_cfg_hash = $(shell if [ -f "$(abspath $(call spec2017_case_cfg,$(1)))" ]; then sha256sum "$(abspath $(call spec2017_case_cfg,$(1)))" | cut -d ' ' -f 1; else printf 'missing'; fi)
 SPEC2017_PYTHON := PYTHONDONTWRITEBYTECODE=1 python3
@@ -178,7 +180,8 @@ $(SPEC2017_BUILD_DIR)/$(1)/firmware/dtb-$(call spec2017_case_dtb_tag,$(1)).stamp
 		"case=$(1)" \
 		"default_dtb=$$(SPEC2017_DEFAULT_DTB)" \
 		"profile=$(call spec2017_case_dtb_profile,$(1))" \
-		"min_memory_bytes=$(call spec2017_case_dtb_min_memory_bytes,$(1))" > "$$@.tmp"
+		"min_memory_bytes=$(call spec2017_case_dtb_min_memory_bytes,$(1))" \
+		"required_min_memory_bytes=$(call spec2017_case_dtb_required_min_memory_bytes,$(1))" > "$$@.tmp"
 	@if [ -f "$$@" ] && cmp -s "$$@.tmp" "$$@"; then rm "$$@.tmp"; else mv "$$@.tmp" "$$@"; fi
 
 $(SPEC2017_BUILD_DIR)/$(1)/fw_payload.bin: $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_GCPT_BIN) $$(SPEC2017_SCRIPTS_DIR)/build-firmware-linux.sh $(SPEC2017_BUILD_DIR)/$(1)/rootfs.cpio $$(SPEC2017_LINUX_IMAGE) $$(SPEC2017_SBI_BIN) $(SPEC2017_BUILD_DIR)/$(1)/firmware/dtb-$(call spec2017_case_dtb_tag,$(1)).stamp
@@ -188,6 +191,7 @@ $(SPEC2017_BUILD_DIR)/$(1)/fw_payload.bin: $$(SPEC2017_DTS_SOURCES) $$(SPEC2017_
 	DEFAULT_DTB="$$(SPEC2017_DEFAULT_DTB)" \
 	DTB_MEMORY_PROFILE="$(call spec2017_case_dtb_profile,$(1))" \
 	DTB_MIN_MEMORY_BYTES="$(call spec2017_case_dtb_min_memory_bytes,$(1))" \
+	DTB_REQUIRED_MIN_MEMORY_BYTES="$(call spec2017_case_dtb_required_min_memory_bytes,$(1))" \
 	MULTIHART="$$(SPEC2017_MULTIHART)" \
 	HARTS="$$(SPEC2017_HARTS)" \
 	SPEC2017_PROGRESS_K="$$(SPEC2017_PROGRESS_K)" \
@@ -230,6 +234,7 @@ $(SPEC2017_IMAGE_DIR)/stamps/$(1).images.stamp: $(SPEC2017_PREPARE_STAMP) $(SPEC
 		DEFAULT_DTB="$$(SPEC2017_DEFAULT_DTB)" \
 		DTB_MEMORY_PROFILE="$(call spec2017_case_dtb_profile,$(1))" \
 		DTB_MIN_MEMORY_BYTES="$(call spec2017_case_dtb_min_memory_bytes,$(1))" \
+		DTB_REQUIRED_MIN_MEMORY_BYTES="$(call spec2017_case_dtb_required_min_memory_bytes,$(1))" \
 		MULTIHART="$$(SPEC2017_MULTIHART)" \
 		HARTS="$$(SPEC2017_HARTS)" \
 		SPEC2017_PROGRESS_K="$$(SPEC2017_PROGRESS_K)" \


### PR DESCRIPTION
- Add a no-AIA, 2-hart XiangShan FPGA DTS with 16 GiB of memory.
- Propagate the 16 GiB multi-hart memory requirement through the SPEC2017 build.
- Update the multi-hart build examples.