### PR TITLE
build(am): package RVH bare-metal regression tests

### DIFF
--- a/workloads/am/rvh-tests/README.md
+++ b/workloads/am/rvh-tests/README.md
@@ -1,0 +1,4 @@
+# RVH Tests Workload
+
+Build and package the RVH bare-metal regression tests from
+`nexus-am/tests/rvh`.

--- a/workloads/am/rvh-tests/build.sh
+++ b/workloads/am/rvh-tests/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+mkdir -p "$PKG_DIR"/{bin,elf}
+make -C "$AM_HOME"/tests/rvh CROSS_COMPILE="$CROSS_COMPILE"
+cp "$AM_HOME"/tests/rvh/build/*.bin "$PKG_DIR"/bin/
+cp "$AM_HOME"/tests/rvh/build/*.elf "$PKG_DIR"/elf/


### PR DESCRIPTION
## Summary

Add a workload-builder recipe to build and package the RVH bare-metal regression tests from `nexus-am`.

This PR only contains the build/packaging logic; the test source remains in `nexus-am`.

## Dependency

This PR depends on the corresponding `nexus-am` PR and should not be merged yet.

After that PR is merged, the `nexus-am` submodule will be updated to the merged commit on the main branch.