### PR TITLE
feat(linux): set unlimited stack size for SPEC runtime scripts

### DIFF
--- a/workloads/linux/spec2006/spec2006-package.py
+++ b/workloads/linux/spec2006/spec2006-package.py
@@ -340,6 +340,7 @@ def write_runtime_files(pkg_dir, case_name, binary_name, args):
                 "set -e",
                 'SPEC_ROOT="${SPEC_ROOT:-/spec}"',
                 "export SPEC_ROOT",
+                "ulimit -s unlimited 2>/dev/null || true",
                 'cd "$SPEC_ROOT"',
                 f"echo '======== BEGIN {case_name} ========'",
                 f"md5sum ./{shlex.quote(binary_name)}",

--- a/workloads/linux/spec2017/spec2017-package.py
+++ b/workloads/linux/spec2017/spec2017-package.py
@@ -922,6 +922,7 @@ def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling, multi
         "mount -t sysfs sysfs /sys 2>/dev/null || true",
         'SPEC_ROOT="${SPEC_ROOT:-/spec}"',
         "export SPEC_ROOT",
+        "ulimit -s unlimited 2>/dev/null || true",
         'cd "$SPEC_ROOT"',
         "export LC_ALL=C",
         "export OMP_NUM_THREADS=1",

--- a/workloads/linux/spec2017/spec2017-package.py
+++ b/workloads/linux/spec2017/spec2017-package.py
@@ -922,7 +922,6 @@ def write_runtime_files(pkg_dir, case_name_value, run_commands, profiling, multi
         "mount -t sysfs sysfs /sys 2>/dev/null || true",
         'SPEC_ROOT="${SPEC_ROOT:-/spec}"',
         "export SPEC_ROOT",
-        "ulimit -s unlimited 2>/dev/null || true",
         'cd "$SPEC_ROOT"',
         "export LC_ALL=C",
         "export OMP_NUM_THREADS=1",

--- a/workloads/linux/spec2026/spec2026-package.py
+++ b/workloads/linux/spec2026/spec2026-package.py
@@ -478,6 +478,7 @@ def write_runtime_files(pkg_dir, case_name, primary_run_dir_name):
             [
                 "#!/bin/sh",
                 "set -e",
+                "ulimit -s unlimited 2>/dev/null || true",
                 f"echo '======== BEGIN {case_name} ========'",
                 "date -R || true",
                 f"cd {target_run_dir}",


### PR DESCRIPTION
- Add `ulimit -s unlimited 2>/dev/null || true` to the `run.sh` generated by the three packaging scripts for spec2006 / spec2017 /  spec2026, setting the stack limit to unlimited at script startup to reduce the risk of run failures caused by the default stack limit.
- +1 line per package script (in `write_runtime_files` / `generate_runtime_script`).
- The `2>/dev/null || true` ensures the script continues executing even if the ulimit adjustment fails or the environment is      
 restricted, so it is not affected by `set -e`.