### PR TITLE
feat(linux): add multihart SPECjbb2015 workload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 
 __pycache__/
 /build
+SPECjbb2015*.iso

--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ returns, and requires `DEFAULT_DTB` to be set to the complete DTS basename.
 Its matching template must exist in `dts/`; the build fails rather than
 guessing a memory profile or generating a missing multi-hart DTS.
 
+SPECjbb2015 can be built from locally supplied licensed media and an RV64 JDK:
+
+```sh
+make linux/specjbb2015 \
+  SPECJBB_INPUT=/path/to/SPECjbb2015-1.03.iso \
+  SPECJBB_RV_JDK_INPUT=/path/to/jdk25 \
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g-novec -jN
+```
+
+The workload uses one multithreaded JVM across all guest harts. See
+`workloads/linux/specjbb2015/README.md` for heap and mode options. The ISO and
+JDK are local inputs and are not redistributed by this repository.
+
+SPECjbb2015 can be built from locally supplied licensed media and an RV64 JDK:
+
+```sh
+make linux/specjbb2015 \
+  SPECJBB_INPUT=/path/to/SPECjbb2015-1.03.iso \
+  SPECJBB_RV_JDK_INPUT=/path/to/jdk25 \
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g-novec -jN
+```
+
+The workload uses one multithreaded JVM across all guest harts. See
+`workloads/linux/specjbb2015/README.md` for heap and mode options. The ISO and
+JDK are local inputs and are not redistributed by this repository.
+
 Single-core firmware uses LibCheckpointAlpha. Multi-core firmware uses
 LibCheckpoint to restore QEMU multi-hart checkpoints. Set `HARTS` to match
 the checkpoint and the selected device-tree template; supported multi-hart

--- a/workloads/linux/specjbb2015/README.md
+++ b/workloads/linux/specjbb2015/README.md
@@ -1,0 +1,21 @@
+# SPECjbb2015 Linux workload
+
+SPECjbb2015 is not distributed with this repository. Set `SPECJBB_INPUT` to a
+licensed ISO, archive, or directory and `SPECJBB_RV_JDK_INPUT` to an RV64 JDK
+25 directory or archive. No benchmark or JDK files are committed.
+
+Build a two-hart XiangShan image:
+
+```sh
+make linux/specjbb2015 \
+  SPECJBB_INPUT=/path/to/SPECjbb2015-1.03.iso \
+  SPECJBB_RV_JDK_INPUT=/path/to/jdk25 \
+  SPECJBB_MODE=COMPOSITE SPECJBB_JVM_XMS=4g SPECJBB_JVM_XMX=4g \
+  MULTIHART=1 HARTS=2 \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-2hart-mem8g-novec -jN
+```
+
+The output is `build/linux-workloads/specjbb2015/fw_payload.bin`. The image
+uses one multithreaded JVM shared by all guest harts and the standard
+multi-hart checkpoint memory layout. The selected DTB must match `HARTS` and
+provide enough memory for the configured Java heap.

--- a/workloads/linux/specjbb2015/build.sh
+++ b/workloads/linux/specjbb2015/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SPECJBB_INPUT:?SPECJBB_INPUT is required (licensed ISO, archive, or directory)}"
+: "${SPECJBB_RV_JDK_INPUT:?SPECJBB_RV_JDK_INPUT is required (RV64 JDK directory or archive)}"
+: "${SPECJBB_JVM_XMS:=4g}"
+: "${SPECJBB_JVM_XMX:=4g}"
+: "${SPECJBB_MODE:=COMPOSITE}"
+
+[[ -e "$SPECJBB_INPUT" ]] || { echo "SPECjbb input not found: $SPECJBB_INPUT" >&2; exit 1; }
+[[ -e "$SPECJBB_RV_JDK_INPUT" ]] || { echo "RV64 JDK input not found: $SPECJBB_RV_JDK_INPUT" >&2; exit 1; }
+[[ "$SPECJBB_MODE" =~ ^[A-Za-z0-9_-]+$ ]] || { echo "Invalid SPECJBB_MODE" >&2; exit 1; }
+
+payload_dir="$PKG_DIR/specjbb2015"
+mkdir -p "$payload_dir/specjbb" "$payload_dir/jdk"
+if [[ -d "$SPECJBB_RV_JDK_INPUT" ]]; then
+  cp -a "$SPECJBB_RV_JDK_INPUT"/. "$payload_dir/jdk/"
+else
+  jdk_stage="$WORKLOAD_BUILD_DIR/jdk-stage"
+  rm -rf "$jdk_stage" && mkdir -p "$jdk_stage"
+  tar -xf "$SPECJBB_RV_JDK_INPUT" -C "$jdk_stage"
+  if [[ -x "$jdk_stage/bin/java" ]]; then
+    cp -a "$jdk_stage"/. "$payload_dir/jdk/"
+  else
+    jdk_root="$(find "$jdk_stage" -mindepth 1 -maxdepth 2 -type f -path '*/bin/java' -printf '%h\n' | sed 's|/bin$||' | head -n 1)"
+    [[ -n "$jdk_root" ]] || { echo "RV64 JDK archive does not contain bin/java" >&2; exit 1; }
+    cp -a "$jdk_root"/. "$payload_dir/jdk/"
+  fi
+fi
+if [[ -d "$SPECJBB_INPUT" ]]; then
+  cp -a "$SPECJBB_INPUT"/. "$payload_dir/specjbb/"
+elif [[ "$SPECJBB_INPUT" == *.iso ]] && command -v 7z >/dev/null 2>&1; then
+  7z x -y "$SPECJBB_INPUT" -o"$payload_dir/specjbb" >/dev/null
+elif [[ "$SPECJBB_INPUT" == *.iso ]] && command -v bsdtar >/dev/null 2>&1; then
+  bsdtar -xf "$SPECJBB_INPUT" -C "$payload_dir/specjbb"
+elif [[ "$SPECJBB_INPUT" == *.iso ]]; then
+  echo "Extracting a SPECjbb ISO requires 7z or bsdtar" >&2
+  exit 1
+else
+  tar -xf "$SPECJBB_INPUT" -C "$payload_dir/specjbb"
+fi
+[[ -x "$payload_dir/jdk/bin/java" ]] || { echo "RV64 JDK bin/java not found after extraction" >&2; exit 1; }
+[[ -f "$payload_dir/specjbb/specjbb2015.jar" ]] || { echo "specjbb2015.jar not found at the input root" >&2; exit 1; }
+install -m 755 "$WORKLOAD_DIR/run.sh" "$payload_dir/run.sh"
+install -m 755 "$WORKLOAD_DIR/launch-multihart.sh" "$payload_dir/launch-multihart.sh"
+install -D -m 644 "$WORKLOAD_DIR/inittab" "$PKG_DIR/etc/inittab"
+{
+  printf 'SPECJBB_JVM_XMS=%q\n' "$SPECJBB_JVM_XMS"
+  printf 'SPECJBB_JVM_XMX=%q\n' "$SPECJBB_JVM_XMX"
+  printf 'SPECJBB_MODE=%q\n' "$SPECJBB_MODE"
+  printf 'SPECJBB_HARTS=%q\n' "${SPECJBB_HARTS:-${HARTS:-2}}"
+} > "$payload_dir/specjbb-workload.conf"

--- a/workloads/linux/specjbb2015/inittab
+++ b/workloads/linux/specjbb2015/inittab
@@ -1,0 +1,1 @@
+::once:/bin/sh /specjbb2015/launch-multihart.sh

--- a/workloads/linux/specjbb2015/launch-multihart.sh
+++ b/workloads/linux/specjbb2015/launch-multihart.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -u
+
+payload_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+. "$payload_dir/specjbb-workload.conf"
+harts="${SPECJBB_HARTS:-2}"
+
+run_on_cpu() {
+  cpu="$1"; shift
+  if [ -x /usr/bin/taskset ]; then /usr/bin/taskset -c "$cpu" "$@"
+  elif [ -x /bin/taskset ]; then /bin/taskset -c "$cpu" "$@"
+  else echo "SPECjbb launcher: taskset not found" >&2; return 127; fi
+}
+
+# profilingv2 starts after the second trap seen on hart 0. Trap 256 is not
+# used because disabling timer interrupts can deadlock a timed Java workload.
+cpu=0
+while [ "$cpu" -lt "$harts" ]; do
+  run_on_cpu "$cpu" /bin/nemu-trap 257 || exit $?
+  cpu=$((cpu + 1))
+done
+run_on_cpu 0 /bin/nemu-trap 257 || exit $?
+
+set +e
+run_on_cpu "0-$((harts - 1))" /bin/sh "$payload_dir/run.sh"
+status=$?
+set -e
+
+cpu=0; pids=""
+while [ "$cpu" -lt "$harts" ]; do
+  run_on_cpu "$cpu" /bin/nemu-trap 258 & pids="$pids $!"
+  cpu=$((cpu + 1))
+done
+for pid in $pids; do wait "$pid"; done
+/bin/nemu-trap "$status"
+exit "$status"

--- a/workloads/linux/specjbb2015/rules.mk
+++ b/workloads/linux/specjbb2015/rules.mk
@@ -1,0 +1,45 @@
+SPECJBB2015_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SPECJBB2015_BUILD_DIR := build/linux-workloads/specjbb2015
+SPECJBB2015_MULTIHART ?= $(MULTIHART)
+SPECJBB2015_HARTS ?= $(if $(HARTS),$(HARTS),2)
+SPECJBB2015_DEFAULT_DTB ?= $(DEFAULT_DTB)
+
+ifeq ($(filter 1,$(SPECJBB2015_MULTIHART)),1)
+ifeq ($(strip $(SPECJBB2015_DEFAULT_DTB)),)
+$(error DEFAULT_DTB is required for SPECjbb multi-hart builds)
+endif
+endif
+
+SPECJBB2015_ROOTFS_HASH := $(shell printf '%s\n' 'harts=$(SPECJBB2015_HARTS)' 'xms=$(SPECJBB_JVM_XMS)' 'xmx=$(SPECJBB_JVM_XMX)' 'mode=$(SPECJBB_MODE)' | sha256sum | cut -d ' ' -f 1)
+SPECJBB2015_ROOTFS_STAMP := $(SPECJBB2015_BUILD_DIR)/rootfs-vars.$(SPECJBB2015_ROOTFS_HASH).stamp
+
+.PHONY: specjbb2015-check-inputs
+specjbb2015-check-inputs:
+	@if [ -z "$(SPECJBB_INPUT)" ] || ! [ -e "$(SPECJBB_INPUT)" ]; then echo "SPECJBB_INPUT must point to licensed SPECjbb2015 media"; exit 1; fi
+	@if [ -z "$(SPECJBB_RV_JDK_INPUT)" ] || ! [ -e "$(SPECJBB_RV_JDK_INPUT)" ]; then echo "SPECJBB_RV_JDK_INPUT must point to an RV64 JDK"; exit 1; fi
+
+$(SPECJBB2015_BUILD_DIR)/download/sentinel:
+	@mkdir -p "$(@D)"
+	@touch "$@"
+
+$(SPECJBB2015_ROOTFS_STAMP):
+	@mkdir -p "$(@D)"
+	@rm -f "$(@D)"/rootfs-vars.*.stamp
+	@touch "$@"
+
+$(SPECJBB2015_BUILD_DIR)/rootfs.cpio: $(shell find $(SPECJBB2015_DIR)) $(TOOLCHAIN_WRAPPER) scripts/build-workload-linux.sh $(SPECJBB2015_BUILD_DIR)/download/sentinel $(SPECJBB2015_ROOTFS_STAMP) | specjbb2015-check-inputs
+	@CROSS_COMPILE="$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
+	  SPECJBB_INPUT="$(SPECJBB_INPUT)" SPECJBB_RV_JDK_INPUT="$(SPECJBB_RV_JDK_INPUT)" \
+	  SPECJBB_JVM_XMS="$(SPECJBB_JVM_XMS)" SPECJBB_JVM_XMX="$(SPECJBB_JVM_XMX)" SPECJBB_MODE="$(SPECJBB_MODE)" \
+	  HARTS="$(SPECJBB2015_HARTS)" MULTIHART=0 \
+	  bash scripts/build-workload-linux.sh workloads/linux/specjbb2015 $(SPECJBB2015_BUILD_DIR)
+
+$(SPECJBB2015_BUILD_DIR)/fw_payload.bin: $(shell find $(abspath dts)) $(GCPT_BIN) scripts/build-firmware-linux.sh $(SPECJBB2015_BUILD_DIR)/rootfs.cpio $(LINUX_IMAGE) $(SBI_BIN)
+	@CROSS_COMPILE="$(abspath $(BUILDROOT_DIR)/output/host/bin)/riscv64-linux-" \
+	  DTC="$(abspath $(BUILDROOT_DIR)/output/host/bin)/dtc" DEFAULT_DTB="$(SPECJBB2015_DEFAULT_DTB)" \
+	  MULTIHART="$(SPECJBB2015_MULTIHART)" HARTS="$(SPECJBB2015_HARTS)" \
+	  bash scripts/build-firmware-linux.sh $(GCPT_BIN) $(SBI_BUILD_DIR) dts $(LINUX_IMAGE) $(SPECJBB2015_BUILD_DIR)
+
+linux/specjbb2015: $(SPECJBB2015_BUILD_DIR)/fw_payload.bin
+WORKLOAD_PHONY_TARGETS += linux/specjbb2015
+WORKLOAD_DIRS += $(SPECJBB2015_BUILD_DIR)

--- a/workloads/linux/specjbb2015/run.sh
+++ b/workloads/linux/specjbb2015/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+payload_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+. "$payload_dir/specjbb-workload.conf"
+export JAVA_HOME="$payload_dir/jdk"
+export PATH="$JAVA_HOME/bin:/bin:/usr/bin" LANG=C LC_ALL=C TZ=UTC
+mkdir -p /proc /sys /tmp
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sysfs /sys 2>/dev/null || true
+cd "$payload_dir/specjbb"
+jar="$payload_dir/specjbb/specjbb2015.jar"
+[ -f "$jar" ] || { echo "SPECjbb jar not found: $jar" >&2; exit 1; }
+exec "$JAVA_HOME/bin/java" -server "-Xms$SPECJBB_JVM_XMS" "-Xmx$SPECJBB_JVM_XMX" -jar "$jar" -m "$SPECJBB_MODE"


### PR DESCRIPTION
## Summary
- add a Linux SPECjbb2015 workload target for XiangShan multi-hart checkpoint flows
- accept licensed SPECjbb media and a local RV64 JDK as build inputs
- add single-JVM multi-hart launcher, DTB/HARTS options, and documentation

## Validation
- bash -n and sh -n checks pass
- Makefile database recognizes linux/specjbb2015
- SPECjbb ISO and JDK are not included in the repository

Full workload build requires the user-provided licensed ISO and RV64 JDK.