### PR TITLE
fix(linux/hello): avoid gp-relative message addressing

### DIFF
--- a/workloads/linux/hello/source/hello.s
+++ b/workloads/linux/hello/source/hello.s
@@ -1,16 +1,27 @@
 .data
-msg:    .asciz "Hello, world!\n"
-len = . - msg - 1
+msg:    .ascii "Hello, world!\n"
+len = . - msg
 
 .text
 .globl _start
 
 _start:
     li a0, 1              # File descriptor: stdout = 1
+    # This is a freestanding entry point, so no C runtime has initialized gp.
+    # Disable linker relaxation to keep symbol addresses PC-relative.
+    .option push
+    .option norelax
     la a1, msg            # Load address of message string
+    .option pop
     li a2, len            # Length of the string
     li a7, 64             # Linux syscall number for write (64)
     ecall                 # Make system call
+    li t0, len
+    bne a0, t0, fail
 
     li a0, 0              # Exit status = 0
     .word 0x0000006b      # NEMU trap instruction
+
+fail:
+    li a0, 1
+    .word 0x0000006b


### PR DESCRIPTION
linux/hello is a freestanding init program entered directly at _start, so no C runtime initializes the global pointer. With linker relaxation enabled, the la pseudo-instruction may be relaxed to a gp-relative addi. That leaves write(2) with an invalid message address on platforms where gp is not incidentally usable, producing a good NEMU trap without printing Hello, world!.

Disable relaxation around the message-address load so it remains PC-relative. Define the message as exactly 14 output bytes and verify that write returns the full length; report a bad NEMU trap when output fails instead of silently claiming success.