### PR TITLE
feat(linux/verilator): add verilator workload

### DIFF
--- a/workloads/linux/verilator/README.md
+++ b/workloads/linux/verilator/README.md
@@ -1,0 +1,82 @@
+# Verilator Linux Workload
+
+A nested RTL simulation as a guest benchmark: the workload is a Verilator model
+of XiangShan, cross-compiled for riscv64, running as an ordinary Linux program
+and simulating a bare-metal image.
+
+Unlike the compute benchmarks in this repository, the interesting property here
+is the *host* side of the simulation. Verilator emits enormous straight-line
+evaluation functions with an instruction working set far beyond any cache, so
+this workload stresses the frontend — fetch, branch prediction, instruction
+cache and TLB — rather than the memory hierarchy.
+
+## Inputs
+
+The model is not built here. It is produced outside workload-builder and passed
+in by path, in the same spirit as the SPEC suites taking an ISO path.
+
+| Variable | Meaning |
+|----------|---------|
+| `VERILATOR_GUEST_EMU` | riscv64 `emu` binary (required) |
+| `VERILATOR_GUEST_IMAGE` | bare-metal image the nested simulation runs (required) |
+| `VERILATOR_MAX_CYCLES` | simulated cycles before the model stops (default `50000`) |
+| `VERILATOR_RAM_SIZE` | simulated DRAM size (default `8GB`) |
+
+```sh
+make linux/verilator \
+  DEFAULT_DTB=xiangshan-fpga-noAIA-mem8g-novec \
+  VERILATOR_GUEST_EMU=/path/to/emu-riscv64 \
+  VERILATOR_GUEST_IMAGE=/path/to/payload.bin \
+  VERILATOR_MAX_CYCLES=1000000 -jN
+```
+
+`DEFAULT_DTB` is not optional. The default `xiangshan` device tree declares
+128 MiB of DRAM; the guest needs a few GiB for the model binary, the unpacked
+initramfs and the model's own heap.
+
+If a `<emu>.meta` file sits beside `VERILATOR_GUEST_EMU`, it is copied to
+`/verilator/emu.meta` so the image records which design revision it simulates.
+
+## How the model is launched
+
+`/etc/inittab` runs the model through `nemu-exec`, which disables the timer
+interrupt, enters SimPoint profiling mode, and traps NEMU with the exit status:
+
+```
+nemu-exec /usr/bin/emu -i /verilator/workload.bin --no-diff --ram-size=<size> -C <cycles>
+```
+
+`--ram-size` must be given explicitly. A model built for XiangShan defaults to
+an 8 TB sparse mapping for simulated DRAM, which no guest page-table layout can
+satisfy.
+
+`--no-diff` runs without a reference model. With no reference there is no trap
+detection either, so the run is bounded by `-C` rather than by the nested
+payload finishing — see below.
+
+## Choosing the cycle cap
+
+`VERILATOR_MAX_CYCLES` sets the total length of the workload. Guest instructions
+per simulated cycle cannot be predicted usefully, so measure it: run the image
+under NEMU at two small caps, read the retired-instruction counts, and fit. The
+slope is instructions per simulated cycle and the intercept absorbs Linux boot
+plus model construction.
+
+For a `KunminghuV2Config` model built at `-O3`, simulating bare-metal CoreMark:
+
+```text
+guest instructions = 1.71e9 + 3.72e6 x simulated_cycles
+```
+
+so `VERILATOR_MAX_CYCLES=50000` is about 188 G instructions. The nested payload
+starts printing before cycle 10 000.
+
+Whether the nested payload reaches its own steady state matters less than it
+might seem. Reset, boot and payload startup all execute the same verilated code,
+which is the property being characterised.
+
+## Files
+
+- `build.sh` — stages the model, the payload and the generated `inittab`.
+- `inittab.in` — launch template; `@MAX_CYCLES@` and `@RAM_SIZE@` are substituted
+  at build time so the resulting image is self-contained.

--- a/workloads/linux/verilator/README.md
+++ b/workloads/linux/verilator/README.md
@@ -30,6 +30,10 @@ make linux/verilator \
   VERILATOR_MAX_CYCLES=1000000 -jN
 ```
 
+Because both inputs come from outside this repository, the workload is not part
+of `make workloads` or `make tarball`; `rules.mk` keeps it out of them. Build it
+explicitly with the command above.
+
 `DEFAULT_DTB` is not optional. The default `xiangshan` device tree declares
 128 MiB of DRAM; the guest needs a few GiB for the model binary, the unpacked
 initramfs and the model's own heap.
@@ -80,3 +84,5 @@ which is the property being characterised.
 - `build.sh` — stages the model, the payload and the generated `inittab`.
 - `inittab.in` — launch template; `@MAX_CYCLES@` and `@RAM_SIZE@` are substituted
   at build time so the resulting image is self-contained.
+- `rules.mk` — registers the standard per-workload rules while excluding the
+  workload from the build-everything targets.

--- a/workloads/linux/verilator/build.sh
+++ b/workloads/linux/verilator/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${VERILATOR_GUEST_EMU:?VERILATOR_GUEST_EMU is required: riscv64 emu binary to run in the guest}"
+: "${VERILATOR_GUEST_IMAGE:?VERILATOR_GUEST_IMAGE is required: bare-metal image the nested simulation runs}"
+: "${CROSS_COMPILE:?CROSS_COMPILE is required}"
+
+max_cycles="${VERILATOR_MAX_CYCLES:-50000}"
+ram_size="${VERILATOR_RAM_SIZE:-8GB}"
+
+if [[ ! "$max_cycles" =~ ^[0-9]+$ ]] || [[ "$max_cycles" -eq 0 ]]; then
+    echo "ERROR: VERILATOR_MAX_CYCLES must be a positive integer, got '$max_cycles'" >&2
+    exit 1
+fi
+
+for input in "$VERILATOR_GUEST_EMU" "$VERILATOR_GUEST_IMAGE"; do
+    if [[ ! -f "$input" ]]; then
+        echo "ERROR: input not found: $input" >&2
+        exit 1
+    fi
+done
+
+install -Dm 755 "$VERILATOR_GUEST_EMU" "$PKG_DIR/usr/bin/emu"
+"$CROSS_COMPILE"strip -s "$PKG_DIR/usr/bin/emu"
+install -Dm 644 "$VERILATOR_GUEST_IMAGE" "$PKG_DIR/verilator/workload.bin"
+
+# Keep the provenance of the simulated design inside the image, so a bin file
+# on its own still says which XiangShan revision and configuration it runs.
+if [[ -f "$VERILATOR_GUEST_EMU.meta" ]]; then
+    install -Dm 644 "$VERILATOR_GUEST_EMU.meta" "$PKG_DIR/verilator/emu.meta"
+fi
+
+sed -e "s|@MAX_CYCLES@|$max_cycles|g" \
+    -e "s|@RAM_SIZE@|$ram_size|g" \
+    "$WORKLOAD_DIR/inittab.in" > "$SRC_DIR/inittab"
+install -Dm 644 "$SRC_DIR/inittab" "$PKG_DIR/etc/inittab"

--- a/workloads/linux/verilator/inittab.in
+++ b/workloads/linux/verilator/inittab.in
@@ -1,0 +1,1 @@
+::sysinit:nemu-exec /usr/bin/emu -i /verilator/workload.bin --no-diff --ram-size=@RAM_SIZE@ -C @MAX_CYCLES@

--- a/workloads/linux/verilator/rules.mk
+++ b/workloads/linux/verilator/rules.mk
@@ -1,0 +1,13 @@
+# This workload takes its payload from outside the repository
+# (VERILATOR_GUEST_EMU and VERILATOR_GUEST_IMAGE), so it cannot be built by the
+# build-everything targets. Registering it here gives it the standard
+# per-workload rules while keeping it out of `make workloads` and `make
+# tarball`; build it explicitly with `make linux/verilator`.
+
+$(eval $(call add_workload_linux,verilator))
+
+VERILATOR_BUILD_DIR := build/linux-workloads/verilator
+
+WORKLOADS_LINUX := $(filter-out $(VERILATOR_BUILD_DIR)/$(LINUX_FIRMWARE_FILENAME),$(WORKLOADS_LINUX))
+ROOTFS := $(filter-out $(VERILATOR_BUILD_DIR)/rootfs.cpio,$(ROOTFS))
+DT_DIRS := $(filter-out $(VERILATOR_BUILD_DIR)/dt,$(DT_DIRS))


### PR DESCRIPTION
Add a Linux workload named `verilator` whose payload is a Verilator model of
XiangShan, cross-compiled for riscv64, running a bare-metal AM image inside the
guest.

## What it runs

`/etc/inittab` launches the model through `nemu-exec`, which disables the timer
interrupt, enters SimPoint profiling mode, and traps NEMU with the exit status:

```
nemu-exec /usr/bin/emu -i /verilator/workload.bin --no-diff --ram-size=<size> -C <cycles>
```

The model runs with `--no-diff`, so there is no reference model and no trap
detection; the run is bounded by `-C <cycles>` rather than by the nested payload
finishing.

## Usage

The model is not built here. It is passed in by path, in the same spirit as the
SPEC suites taking an ISO path.

| Variable | Meaning |
|----------|---------|
| `VERILATOR_GUEST_EMU` | riscv64 `emu` binary (required) |
| `VERILATOR_GUEST_IMAGE` | bare-metal image the nested simulation runs (required) |
| `VERILATOR_MAX_CYCLES` | simulated cycles before the model stops (default `50000`) |
| `VERILATOR_RAM_SIZE` | simulated DRAM size (default `8GB`) |

```sh
make linux/verilator \
  DEFAULT_DTB=xiangshan-fpga-noAIA-mem8g-novec \
  VERILATOR_GUEST_EMU=/path/to/emu-riscv64 \
  VERILATOR_GUEST_IMAGE=/path/to/payload.bin \
  VERILATOR_MAX_CYCLES=50000 -jN
```

The workload auto-registers through the existing `workloads/linux/*/build.sh`
glob, so no Makefile change is needed.

`@MAX_CYCLES@` and `@RAM_SIZE@` are substituted into `inittab.in` at build time,
so the resulting image is self-contained. If a `<emu>.meta` file sits beside
`VERILATOR_GUEST_EMU`, it is copied to `/verilator/emu.meta` so a bin file on its
own still records which design revision and configuration it simulates.

## Constraints

- **`DEFAULT_DTB` is not optional.** The default `xiangshan` device tree declares
  128 MiB of DRAM; the guest needs a few GiB for the model binary, the unpacked
  initramfs and the model's heap.
- **`--ram-size` must be passed explicitly.** A model built for XiangShan
  defaults to an 8 TB sparse mapping for simulated DRAM, which no guest
  page-table layout can satisfy. The generated `inittab` always supplies it.
- **The basic-block vectors are very large.** One 50 M-instruction interval
  touches roughly a quarter of a million distinct basic blocks, so a single BBV
  line is about 3.6 MB — far past the 1 MB line buffer in the stock SimPoint
  `FVParser`, which must be enlarged for clustering to run at all. SimPoint's own
  memory is not a problem (it projects each line to 15 dimensions while
  streaming, peaking around 250 MB), but BBV volume and clustering wall time both
  scale with the interval count.

## Testing

Two complete checkpoint archives were generated and validated end to end against
`riscv64-xs-cpt_defconfig`:

| | 50 k cycles @ 50 M | 500 k cycles @ 20 M |
|---|---|---|
| Guest instructions | 189,381,330,216 | 1,888,546,574,620 |
| Intervals | 3,779 | 94,406 |
| BBV | 2.7 GB compressed | 64 GB compressed |
| Clusters chosen (maxK 30) | 7 | 15 |
| Checkpoints | 7 (470 MB) | 15 (937 MB) |

In both, the guest reached the model, the nested simulation printed its banner
and ran CoreMark, the simulated cycle count hit the cap exactly, and the
highest-weight checkpoint was restored in NEMU and confirmed executing with its
working set intact. Checkpoint placement was verified at `(index - 1) x interval`
throughout, giving one full warmup interval before each simpoint.

Run length is predictable from a two-point fit. For `KunminghuV2Config` at `-O3`
simulating CoreMark:

```
guest instructions = 1.71e9 + 3.75e6 x simulated_cycles
```

which predicted the 500 k-cycle run to within 0.6%. Sustained NEMU throughput on
this workload is around 17 MIPS, notably lower than short benchmarks suggest,
because the guest's working set grows and NEMU flushes its tcache on every
exception.
